### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ and optimization tools in real-world mesh optical networks.**
 
 `gnpy <http://github.com/telecominfraproject/oopt-gnpy>`__ is:
 
-- a sponsored project of the `OOPT/PSE <https://telecominfraproject.com/open-optical-packet-transport/>`_ working group of the `Telecom Infra Project <http://telecominfraproject.com>`_.
+- a sponsored project of the `OOPT/PSE <https://telecominfraproject.com/open-optical-packet-transport/>`_ working group of the `Telecom Infra Project <http://telecominfraproject.com>`_
 - fully community-driven, fully open source library
 - driven by a consortium of operators, vendors, and academic researchers
 - intended for rapid development of production-grade route planning tools
@@ -118,8 +118,8 @@ By default, this script operates on a single span network defined in
 `examples/edfa_example_network.json <examples/edfa_example_network.json>`_
 
 You can specify a different network at the command line as follows. For
-example, to use the CORONET Continental US (CONUS) network defined in
-`examples/coronet_conus_example.json <examples/coronet_conus_example.json>`_:
+example, to use the CORONET Global network defined in
+`examples/CORONET_Global_Topology.json <examples/CORONET_Global_Topology.json>`_:
 
 .. code-block:: shell
 
@@ -133,10 +133,10 @@ further instructions on how to prepare the Excel input file, see
 `Excel_userguide.rst <Excel_userguide.rst>`_.
 
 The main transmission example will calculate the average signal OSNR and SNR
-across 93 network elements (transceiver, ROADMs, fibers, and amplifiers)
-between two transceivers selected by the user. (By default, for the CORONET US
-network, it will show the transmission of spectral information between Abilene,
-Texas and Albany, New York.)
+across network elements (transceiver, ROADMs, fibers, and amplifiers)
+between two transceivers selected by the user. (By default, for the CORONET Global
+network, it will show the transmission of spectral information between Albuquerque,
+New Mexico and Atlanta, Georgia.)
 
 This script calculates the average signal OSNR = |OSNR| and SNR = |SNR|.
 
@@ -194,7 +194,7 @@ The fiber library currently describes SSMF but additional fiber types can be ent
 +----------------------+-----------+-----------------------------------------+
 | field                | type      | description                             |
 +======================+===========+=========================================+
-| `type_variety`       | (string)  | a unique name to ID the amplifier in the|
+| `type_variety`       | (string)  | a unique name to ID the fiber in the    |
 |                      |           | JSON or Excel template topology input   |
 |                      |           | file                                    |
 +----------------------+-----------+-----------------------------------------+
@@ -211,7 +211,7 @@ path_request_run.py routine.
 +----------------------+-----------+-----------------------------------------+
 | field                | type      | description                             |
 +======================+===========+=========================================+
-|  `type_variety`      | (string)  | a unique name to ID the amplifier in    |
+|  `type_variety`      | (string)  | a unique name to ID the transceiver in  |
 |                      |           | the JSON or Excel template topology     |
 |                      |           | input file                              |
 +----------------------+-----------+-----------------------------------------+
@@ -237,7 +237,7 @@ The modes are defined as follows:
 +----------------------+-----------+-----------------------------------------+
 | `bit_rate`           | (number)  | in bit/s                                |
 +----------------------+-----------+-----------------------------------------+
-| `roll_off`           | (number)  |                                         |
+| `roll_off`           | (number)  | Not used.                               |
 +----------------------+-----------+-----------------------------------------+
 
 Simulation parameters are defined as follows.
@@ -254,8 +254,8 @@ For amplifiers defined in the topology JSON input but whose gain = 0
 (placeholder), auto-design will set its gain automatically: see `power_mode` in
 the `Spans` library to find out how the gain is calculated.
 
-Span configuration is performed as followws. It is not a list (which may change
-in later releases,) and the user can only modify the value of existing
+Span configuration is performed as follows. It is not a list (which may change
+in later releases) and the user can only modify the value of existing
 parameters:
 
 +------------------------+-----------+---------------------------------------------+
@@ -452,11 +452,6 @@ script propagates a specrum of 96 channels at 32 Gbaud, 50 GHz spacing and 0
 dBm/channel. These are not yet parametrized but can be modified directly in the
 script (via the SpectralInformation structure) to accomodate any baud rate,
 spacing, power or channel count demand.
-
-The amplifier's gain is set to exactly compensate for the loss in each network
-element. The amplifier is currently defined with gain range of 15 dB to 25 dB
-and 21 dBm max output power. Ripple and NF models are defined in
-`examples/std_medium_gain_advanced_config.json <examples/std_medium_gain_advanced_config.json>`_
 
 Use `examples/path_requests_run.py <examples/path_requests_run.py>`_ to run multiple optimizations as follows:
 


### PR DESCRIPTION
Some fixes to the README:

- Tried to fix #127 (also removed reference to 93 network elements since I don't think it was correct).

- Removed some text about amplifier setting in relation to transmission_main_example.py since this script does not use advanced EDFA model by default.

- Other minor fixes.

