### PR TITLE
Some modifications in split_fiber function

### DIFF
--- a/gnpy/core/network.py
+++ b/gnpy/core/network.py
@@ -337,23 +337,17 @@ def split_fiber(network, fiber, bounds, target_length, equipment):
         print(f'{repr(fiber)} is not properly connected, please check network topology')
         exit()
 
-    network.remove_edge(fiber, next_node)
-    network.remove_edge(prev_node, fiber)
     network.remove_node(fiber)
-    # update connector loss parameter with default values
+
     fiber_params = fiber.params._asdict()
+    fiber_params['length'] = new_length / UNITS[fiber.params.length_units]
     fiber_params['con_in'] = fiber.con_in
     fiber_params['con_out'] = fiber.con_out
-    new_spans = [
-        Fiber(
-            uid =      f'{fiber.uid}_({span}/{n_spans})',
-            metadata = fiber.metadata,
-            params = fiber_params
-        ) for span in range(n_spans)
-    ]
-    for new_span in new_spans:
-        new_span.length = new_length
-        network.add_node(new_span)
+    
+    for span in range(n_spans):
+        new_span = Fiber(uid =      f'{fiber.uid}_({span}/{n_spans})',
+                          metadata = fiber.metadata,
+                          params = fiber_params)
         network.add_edge(prev_node, new_span)
         prev_node = new_span
     network.add_edge(prev_node, next_node)

--- a/gnpy/core/network.py
+++ b/gnpy/core/network.py
@@ -345,7 +345,7 @@ def split_fiber(network, fiber, bounds, target_length, equipment):
     fiber_params['con_out'] = fiber.con_out
     
     for span in range(n_spans):
-        new_span = Fiber(uid =      f'{fiber.uid}_({span}/{n_spans})',
+        new_span = Fiber(uid =      f'{fiber.uid}_({span+1}/{n_spans})',
                           metadata = fiber.metadata,
                           params = fiber_params)
         network.add_edge(prev_node, new_span)


### PR DESCRIPTION
Some small modifications in the `split_fiber` function in `network.py`:

- It's not necessary to remove edges since removing a node also removes all adjacent edges.

- It's not necessary to add nodes since adding edges between nodes also adds the nodes.

- Also update `Fiber.params.length` for new spans. Before only `Fiber.length` was updated which means `Fiber.params.length` and `Fiber.length` were inconsistent.

- Change numbering of spans in fiber uids from (0/n to (n-1)/n) to less confusing (1/n to n/n).