### PR TITLE
gain-mode fix

### DIFF
--- a/gnpy/core/elements.py
+++ b/gnpy/core/elements.py
@@ -491,6 +491,8 @@ class Edfa(Node):
         if self.dp_db is not None:
             self.target_pch_db = round(self.dp_db + pref.p0, 2)
             self.effective_gain = self.target_pch_db - pref.pi
+        else:
+            self.effective_gain = self.operational.gain_target
         
         self.effective_gain = min(self.effective_gain, self.params.p_max - self.pin_db)
         self.effective_pch_db = round(pref.pi + self.effective_gain, 2)


### PR DESCRIPTION
This reverts a previous small change that accidentally led to all Edfas having effective gain = 0 in gain mode.