### PR TITLE
fix changed spelling & misspellings in meshTopolgyExampleV2_Services.json for "synchronize/synchronization"

### DIFF
--- a/examples/meshTopologyExampleV2_services.json
+++ b/examples/meshTopologyExampleV2_services.json
@@ -136,9 +136,9 @@
       }
     }
   ],
-  "synchronisation": [
+  "synchronization": [
     {
-      "synchonization-id": 0,
+      "synchronization-id": 0,
       "svec": {
         "relaxable": "False",
         "link-diverse": "True",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "synchonization-id": 3,
+      "synchronization-id": 3,
       "svec": {
         "relaxable": "False",
         "link-diverse": "True",


### PR DESCRIPTION
Fix for issue #152 