### PR TITLE
handling of --verbose

### DIFF
--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -40,7 +40,7 @@ parser = ArgumentParser(description = 'A function that computes performances for
 parser.add_argument('network_filename', nargs='?', type = Path, default= Path(__file__).parent / 'meshTopologyExampleV2.xls')
 parser.add_argument('service_filename', nargs='?', type = Path, default= Path(__file__).parent / 'meshTopologyExampleV2.xls')
 parser.add_argument('eqpt_filename', nargs='?', type = Path, default=Path(__file__).parent / 'eqpt_config.json')
-parser.add_argument('-v', '--verbose', action='count', default=0)
+parser.add_argument('-v', '--verbose', action='count', default=0, help='increases verbosity for each occurence')
 parser.add_argument('-o', '--output')
 
 

--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -40,8 +40,8 @@ parser = ArgumentParser(description = 'A function that computes performances for
 parser.add_argument('network_filename', nargs='?', type = Path, default= Path(__file__).parent / 'meshTopologyExampleV2.xls')
 parser.add_argument('service_filename', nargs='?', type = Path, default= Path(__file__).parent / 'meshTopologyExampleV2.xls')
 parser.add_argument('eqpt_filename', nargs='?', type = Path, default=Path(__file__).parent / 'eqpt_config.json')
-parser.add_argument('-v', '--verbose', action='count')
-parser.add_argument('-o', '--output', default=None)
+parser.add_argument('-v', '--verbose', action='count', default=0)
+parser.add_argument('-o', '--output')
 
 
 def requests_from_json(json_data,equipment):
@@ -243,7 +243,7 @@ def path_result_json(pathresult):
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    basicConfig(level={2: DEBUG, 1: INFO, 0: CRITICAL}.get(args.verbose, CRITICAL))
+    basicConfig(level={2: DEBUG, 1: INFO, 0: CRITICAL}.get(args.verbose, DEBUG))
     logger.info(f'Computing path requests {args.service_filename} into JSON format')
     # for debug
     # print( args.eqpt_filename)

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -116,7 +116,7 @@ parser = ArgumentParser()
 parser.add_argument('-e', '--equipment', type=Path,
                     default=Path(__file__).parent / 'eqpt_config.json')
 parser.add_argument('-pl', '--plot', action='store_true')
-parser.add_argument('-v', '--verbose', action='count', default=0)
+parser.add_argument('-v', '--verbose', action='count', default=0, help='increases verbosity for each occurence')
 parser.add_argument('-l', '--list-nodes', action='store_true', help='list all transceiver nodes')
 parser.add_argument('-po', '--power', default=0, help='channel ref power in dBm')
 #parser.add_argument('-plb', '--power-lower-bound', default=0, help='power sweep lower bound')

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -115,9 +115,9 @@ def main(network, equipment, source, destination, req = None):
 parser = ArgumentParser()
 parser.add_argument('-e', '--equipment', type=Path,
                     default=Path(__file__).parent / 'eqpt_config.json')
-parser.add_argument('-pl', '--plot', action='store_true', default=False)
-parser.add_argument('-v', '--verbose', action='count')
-parser.add_argument('-l', '--list-nodes', action='store_true', default=False, help='list all transceiver nodes')
+parser.add_argument('-pl', '--plot', action='store_true')
+parser.add_argument('-v', '--verbose', action='count', default=0)
+parser.add_argument('-l', '--list-nodes', action='store_true', help='list all transceiver nodes')
 parser.add_argument('-po', '--power', default=0, help='channel ref power in dBm')
 #parser.add_argument('-plb', '--power-lower-bound', default=0, help='power sweep lower bound')
 #parser.add_argument('-pub', '--power-upper-bound', default=1, help='power sweep upper bound')
@@ -129,7 +129,7 @@ parser.add_argument('destination',   nargs='?', help='destination node')
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    basicConfig(level={0: ERROR, 1: INFO, 2: DEBUG}.get(args.verbose, ERROR))
+    basicConfig(level={0: ERROR, 1: INFO, 2: DEBUG}.get(args.verbose, DEBUG))
 
     equipment = load_equipment(args.equipment)
     # logger.info(equipment)


### PR DESCRIPTION
Small change of the handling of the optional `--verbose` argument in example scripts. With this change, when the count is higher than the highest specified level (currently `2: DEBUG`), the logging is set to the highest level instead of the lowest level (`0: CRITICAL` or `ERROR`)  as before. (Note that before, `args.verbose` was never actually set to `0` since no `--verbose` argument defaulted to `args.verbose=None`).

Also remove some unnecessary default values.