### PR TITLE
Add Tx OSNR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,6 +253,8 @@ The modes are defined as follows:
 +----------------------+-----------+-----------------------------------------+
 | `roll_off`           | (number)  | Not used.                               |
 +----------------------+-----------+-----------------------------------------+
+| `tx_osnr`            | (number)  | In dB. OSNR out from transponder.       |
++----------------------+-----------+-----------------------------------------+
 
 Simulation parameters are defined as follows.
 
@@ -443,6 +445,8 @@ one power/channel definition.
 | `OSNR`               | (number)  | Not used.                                 |
 +----------------------+-----------+-------------------------------------------+
 | `bit_rate`           | (number)  | Not used.                                 |
++----------------------+-----------+-------------------------------------------+
+| `tx_osnr`            | (number)  | In dB. OSNR out from transponder.         |
 +----------------------+-----------+-------------------------------------------+
 | `power_dbm`          | (number)  | Reference channel power. In gain mode     |
 |                      |           | (see spans/power_mode = false), all gain  |

--- a/examples/eqpt_config.json
+++ b/examples/eqpt_config.json
@@ -101,6 +101,7 @@
             "roll_off": 0.15,
             "OSNR": 11,
             "bit_rate":100e9,
+            "tx_osnr": 45,
             "cost":1
             }],
       "Transceiver":[
@@ -118,6 +119,7 @@
                        "OSNR": 11,
                        "bit_rate": 100e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 45,
                        "cost":1
                        },
                        {
@@ -126,6 +128,7 @@
                        "OSNR": 15,
                        "bit_rate": 200e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 45,
                        "cost":1
                        }
                    ]
@@ -143,6 +146,7 @@
                        "OSNR": 12,
                        "bit_rate": 100e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 45,
                        "cost":1
                        },
                        {
@@ -151,6 +155,7 @@
                        "OSNR": 18,
                        "bit_rate": 300e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 45,
                        "cost":1
                        },
                        {
@@ -159,6 +164,7 @@
                        "OSNR": 21,
                        "bit_rate": 400e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 45,
                        "cost":1
                        },
                        {
@@ -167,6 +173,7 @@
                        "OSNR": 16,
                        "bit_rate": 200e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 45,
                        "cost":1
                        }
                    ]

--- a/gnpy/core/equipment.py
+++ b/gnpy/core/equipment.py
@@ -27,7 +27,7 @@ Spans = namedtuple('Spans', 'power_mode delta_power_range_db max_length length_u
 Transceiver = namedtuple('Transceiver', 'type_variety frequency mode')
 Roadms = namedtuple('Roadms', 'gain_mode_default_loss power_mode_pref')
 SI = namedtuple('SI', 'f_min f_max baud_rate spacing roll_off \
-                       power_dbm power_range_db OSNR bit_rate cost')
+                       power_dbm power_range_db OSNR bit_rate tx_osnr cost')
 AmpBase = namedtuple(
     'AmpBase',
     'type_variety type_def gain_flatmax gain_min p_max'
@@ -199,6 +199,7 @@ def trx_mode_params(equipment, trx_type_variety='', trx_mode='', error_message=F
             trx_params['nb_channel'] = automatic_nch(trx_params['frequency']['min'],
                                         trx_params['frequency']['max'],
                                         trx_params['spacing'])
+            trx_params['tx_osnr'] = default_si_data.tx_osnr
             nch = automatic_nch(trx_params['frequency']['min'],
                                                       trx_params['frequency']['max'],
                                                       trx_params['spacing'])

--- a/gnpy/core/info.py
+++ b/gnpy/core/info.py
@@ -11,7 +11,7 @@ This module contains classes for modelling SpectralInformation.
 
 from collections import namedtuple
 from numpy import array
-from gnpy.core.utils import lin2db
+from gnpy.core.utils import lin2db, db2lin
 from json import loads
 from gnpy.core.utils import load_json
 
@@ -56,13 +56,14 @@ def merge_input_spectral_information(*si):
     #TODO
     pass
 
-def create_input_spectral_information(f_min, roll_off, baud_rate, power, spacing, nb_channel):
+def create_input_spectral_information(f_min, roll_off, baud_rate, power, spacing, nb_channel, tx_osnr):
     # pref in dB : convert power lin into power in dB
     pref = lin2db(power * 1e3)
+    ase_power = (power / db2lin(tx_osnr)) * (baud_rate / 12.5e9)
     si = SpectralInformation(pref=Pref(pref, pref))
     si = si.update(carriers=[
             Channel(f, (f_min+spacing*f),
-            baud_rate, roll_off, Power(power, 0, 0)) for f in range(1,nb_channel+1)
+            baud_rate, roll_off, Power(power, 0, ase_power)) for f in range(1,nb_channel+1)
             ])
     return si
 

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -34,7 +34,7 @@ logger = getLogger(__name__)
 
 
 RequestParams = namedtuple('RequestParams','request_id source destination trx_type'+
-' trx_mode nodes_list loose_list spacing power nb_channel frequency format baud_rate OSNR bit_rate roll_off cost path_bandwidth')
+' trx_mode nodes_list loose_list spacing power nb_channel frequency format baud_rate OSNR bit_rate roll_off tx_osnr cost path_bandwidth')
 DisjunctionParams = namedtuple('DisjunctionParams','disjunction_id relaxable link_diverse node_diverse disjunctions_req')
 
 class Path_request:
@@ -56,6 +56,7 @@ class Path_request:
         self.OSNR       = params.OSNR
         self.bit_rate   = params.bit_rate
         self.roll_off   = params.roll_off
+        self.tx_osnr    = params.tx_osnr
         self.cost       = params.cost
         self.path_bandwidth  = params.path_bandwidth
 
@@ -385,8 +386,8 @@ def propagate(path, req, equipment, show=False):
     #update roadm loss in case of power sweep (power mode only)
     set_roadm_loss(path, equipment, lin2db(req.power*1e3))
     si = create_input_spectral_information(
-        req.frequency['min'], req.roll_off,
-        req.baud_rate, req.power, req.spacing, req.nb_channel)
+        req.frequency['min'], req.roll_off, req.baud_rate,
+        req.power, req.spacing, req.nb_channel, req.tx_osnr)
     for el in path:
         si = el(si)
         if show :
@@ -415,7 +416,7 @@ def propagate_and_optimize_mode(path, req, equipment, show=False):
             # TODO : if the loop in mode optimization does not have a feasible path, then bugs
             si = create_input_spectral_information(
             req.frequency['min'], equipment['SI']['default'].roll_off,
-            b, req.power, req.spacing, req.nb_channel)
+            b, req.power, req.spacing, req.nb_channel, req.tx_osnr)
             for el in path:
                 si = el(si)
                 if show :

--- a/tests/data/eqpt_config.json
+++ b/tests/data/eqpt_config.json
@@ -78,6 +78,7 @@
             "roll_off": 0.15,
             "OSNR": 15,
             "bit_rate":100e9,
+            "tx_osnr": 100,
             "cost":1
             }],
       "Transceiver":[
@@ -94,6 +95,7 @@
                        "OSNR": 11,
                        "bit_rate": 100e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 100,
                        "cost":1
                        },
                        {
@@ -102,6 +104,7 @@
                        "OSNR": 15,
                        "bit_rate": 200e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 100,
                        "cost":1                       
                        }
                    ]
@@ -119,6 +122,7 @@
                        "OSNR": 19,
                        "bit_rate": 200e9,
                        "roll_off": 0.15,
+                       "tx_osnr": 100,
                        "cost":1
                        }
                    ]

--- a/tests/test_amplifier.py
+++ b/tests/test_amplifier.py
@@ -66,7 +66,7 @@ def setup_trx():
 def si(nch_and_spacing, bw):
     """parametrize a channel comb with nb_channel, spacing and signal bw"""
     nb_channel, spacing = nch_and_spacing
-    return create_input_spectral_information(191.3e12, 0.15, bw, 1e-3, spacing, nb_channel)
+    return create_input_spectral_information(191.3e12, 0.15, bw, 1e-3, spacing, nb_channel, 45)
 
 @pytest.mark.parametrize("gain, nf_expected", [(10, 15), (15, 10), (25, 5.8)])
 def test_variable_gain_nf(gain, nf_expected, setup_edfa_variable_gain, si):

--- a/tests/test_amplifier.py
+++ b/tests/test_amplifier.py
@@ -66,7 +66,7 @@ def setup_trx():
 def si(nch_and_spacing, bw):
     """parametrize a channel comb with nb_channel, spacing and signal bw"""
     nb_channel, spacing = nch_and_spacing
-    return create_input_spectral_information(191.3e12, 0.15, bw, 1e-3, spacing, nb_channel, 45)
+    return create_input_spectral_information(191.3e12, 0.15, bw, 1e-3, spacing, nb_channel, 100)
 
 @pytest.mark.parametrize("gain, nf_expected", [(10, 15), (15, 10), (25, 5.8)])
 def test_variable_gain_nf(gain, nf_expected, setup_edfa_variable_gain, si):


### PR DESCRIPTION
This adds support for a Tx OSNR parameter, see #116. ASE noise out from the transponder is set in the `create_input_spectral_information` function according to this parameter.

The Tx OSNR parameter is defined in `eqpt_config.json`. Currently it is set to a high value, 45 dB, both in SI default and in all trx modes.

So far, no distinction is made between in-band and out-of-band Tx OSNR. Penalty due to ASE noise from other transponders and filterless add/drop is not taken into account.

