### PR TITLE
Corrections

### DIFF
--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -25,7 +25,7 @@ from gnpy.core.service_sheet import convert_service_sheet, Request_element, Elem
 from gnpy.core.utils import load_json
 from gnpy.core.network import load_network, build_network, set_roadm_loss, save_network
 from gnpy.core.equipment import load_equipment, trx_mode_params, automatic_nch, automatic_spacing
-from gnpy.core.elements import Transceiver, Roadm, Edfa, Fused
+from gnpy.core.elements import Transceiver, Roadm, Edfa, Fused, Fiber
 from gnpy.core.utils import db2lin, lin2db
 from gnpy.core.request import (Path_request, Result_element, compute_constrained_path,
                               propagate, jsontocsv, Disjunction, compute_path_dsjctn, requests_aggregation,
@@ -44,7 +44,7 @@ parser.add_argument('network_filename', nargs='?', type = Path, default= Path(__
 parser.add_argument('service_filename', nargs='?', type = Path, default= Path(__file__).parent / 'meshTopologyExampleV2.xls')
 parser.add_argument('eqpt_filename', nargs='?', type = Path, default=Path(__file__).parent / 'eqpt_config.json')
 parser.add_argument('-v', '--verbose', action='count', default=0, help='increases verbosity for each occurence')
-parser.add_argument('-o', '--output')
+parser.add_argument('-o', '--output', type = Path)
 
 
 def requests_from_json(json_data,equipment):
@@ -226,7 +226,9 @@ def correct_route_list(network, pathreqlist):
     # prepares the format of route list of nodes to be consistant
     # remove wrong names, remove endpoints
     # also correct source and destination
-    anytype = [n.uid for n in network.nodes() if not isinstance(n, Transceiver)]
+    anytype = [n.uid for n in network.nodes() if not isinstance(n, Transceiver) and not isinstance(n, Fiber)]
+    # TODO there is a problem of identification of fibers in case of parallel fibers bitween two adjacent roadms
+    # so fiber constraint is not supported
     transponders = [n.uid for n in network.nodes() if isinstance(n, Transceiver)]
     for pathreq in pathreqlist:
         for i,n_id in enumerate(pathreq.nodes_list):
@@ -249,7 +251,6 @@ def correct_route_list(network, pathreqlist):
                     msg = f'could not find node : {n_id} in network topology. Strict constraint can not be applied.'
                     logger.critical(msg)
                     raise ValueError(msg)
-
         if pathreq.source not in transponders:
             msg = f'Request: {pathreq.request_id}: could not find transponder source : {pathreq.source}.'
             logger.critical(msg)
@@ -363,9 +364,10 @@ if __name__ == '__main__':
         for i,p in enumerate(propagatedpths):
             result.append(Result_element(rqs[i],p))
         temp = path_result_json(result)
-        with open(args.output, 'w', encoding='utf-8') as f:
+        fnamecsv = f'{str(args.output)[0:len(str(args.output))-len(str(args.output.suffix))]}.csv'
+        fnamejson = f'{str(args.output)[0:len(str(args.output))-len(str(args.output.suffix))]}.json'
+        with open(fnamejson, 'w', encoding='utf-8') as f:
             f.write(dumps(path_result_json(result), indent=2, ensure_ascii=False))
-            fnamecsv = next(s for s in args.output.split('.')) + '.csv'
             with open(fnamecsv,"w", encoding='utf-8') as fcsv :
                 jsontocsv(temp,equipment,fcsv)
 

--- a/gnpy/core/convert.py
+++ b/gnpy/core/convert.py
@@ -285,10 +285,15 @@ def eqpt_connection_by_city(city_name):
         # Then len(other_cities) == 2
         direction = ['ingress', 'egress']
         for i in range(2):
-            from_ = fiber_link(other_cities[i], city_name)
-            in_ = eqpt_in_city_to_city(city_name, other_cities[0],direction[i])
-            to_ = fiber_link(city_name, other_cities[1-i])
-            subdata += connect_eqpt(from_, in_, to_)
+            try:
+                from_ = fiber_link(other_cities[i], city_name)
+                in_ = eqpt_in_city_to_city(city_name, other_cities[0],direction[i])
+                to_ = fiber_link(city_name, other_cities[1-i])
+                subdata += connect_eqpt(from_, in_, to_)
+            except IndexError:
+                msg = f'In {__name__} eqpt_connection_by_city:\n\t{city_name} is not properly connected'
+                print(msg)
+                exit(1)
     elif nodes_by_city[city_name].node_type.lower() == 'roadm':
         for other_city in other_cities:
             from_ = f'roadm {city_name}'

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -307,7 +307,7 @@ def compute_constrained_path(network, req):
             candidate.sort(key=lambda x: len(x))
             total_path = candidate[0]
         else:
-            if req.loose_list[req.nodes_list.index(n)] == 'loose':
+            if req.loose_list[1] == 'loose':
                 print(f'Request {req.request_id} could not find a path crossing {nodes_list} in network topology')
                 print(f'constraint ignored')
                 total_path = dijkstra_path(network, source, destination)
@@ -421,9 +421,12 @@ def propagate_and_optimize_mode(path, req, equipment, show=False):
                 if show :
                     print(el)
             for m in modes_to_explore :
-                if round(mean(path[-1].snr+lin2db(b/(12.5e9))),2) > m['OSNR'] :
-                    found_a_feasible_mode = True
-                    return path, m
+                if path[-1].snr is not None:
+                    if round(mean(path[-1].snr+lin2db(b/(12.5e9))),2) > m['OSNR'] :
+                        found_a_feasible_mode = True
+                        return path, m
+                else:  
+                    return [], None
         # only get to this point if no budrate/mode staisfies OSNR requirement
         # returns the last propagated path and mode
         msg = f'Warning! Request {req.request_id}: no mode satisfies path SNR requirement.\n'

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -588,7 +588,8 @@ def compute_path_dsjctn(network, equipment, pathreqlist, disjunctions_list):
     for pathreq in pathreqlist_disjt :
         all_simp_pths = list(all_simple_paths(network,\
             source=next(el for el in network.nodes() if el.uid == pathreq.source),\
-            target=next(el for el in network.nodes() if el.uid == pathreq.destination)))
+            target=next(el for el in network.nodes() if el.uid == pathreq.destination),\
+            cutoff=80))
         # sort them
         all_simp_pths = sorted(all_simp_pths, key=lambda path: len(path))
         # reversed direction paths required to check disjunction on both direction

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -275,6 +275,7 @@ def compute_constrained_path(network, req):
     destination = next(el for el in trx if el.uid == req.destination)
     nodes_list = []
     for n in req.nodes_list :
+        # for debug excel print(n)
         nodes_list.append(next(el for el in anytypenode if el.uid == n))
     # nodes_list contains at least the destination
     if nodes_list is None :
@@ -296,7 +297,7 @@ def compute_constrained_path(network, req):
             total_path = []        
     else : 
         all_simp_pths = list(all_simple_paths(network,source=source,\
-            target=destination))
+            target=destination, cutoff=120))
         candidate = []
         for p in all_simp_pths :
             if ispart(nodes_list, p) :
@@ -463,7 +464,7 @@ def jsontocsv(json_data,equipment,fileout):
         # selects only roadm nodes
         pth        = ' | '.join([ e['path-route-object']['unnumbered-hop']['node-id']
                  for e in p['path-properties']['path-route-objects'] 
-                 if e['path-route-object']['unnumbered-hop']['node-id'].startswith('roadm')])
+                 if e['path-route-object']['unnumbered-hop']['node-id'].startswith('roadm') or e['path-route-object']['unnumbered-hop']['node-id'].startswith('Edfa')])
 
         [tsp,mode] = p['path-properties']['path-route-objects'][0]\
         ['path-route-object']['unnumbered-hop']['hop-type'].split(' - ')


### PR DESCRIPTION
Several fixes handling some bugs

- output file of -o option in path_requests_run.py was not correctly
  handled in case of path indirection eg ../../bar.foo
- fiber constraint is not correctly handled in case of several parrallel directions
  of same fiber name. remove if from the set of constraint till problem is not solved
  This will need additional work to be compliant with fiber constraint
- loose_list was not correctly indexed in request.py. assume the first element attribute (except
  of the transceiver) applies for the whole list. 
  This is a fast patch and will need further corrections to handle a detail per node loose definition
- handle the case when path.snr is none in the optimization of mode process
  maybe addresses part of #178 
- a cutoff value needed when networks have a great number of nodes and links (tested on ~ 500)
