### PR TITLE
Add weight edge

### DIFF
--- a/gnpy/core/network.py
+++ b/gnpy/core/network.py
@@ -66,7 +66,13 @@ def network_from_json(json_data, equipment):
     for cx in json_data['connections']:
         from_node, to_node = cx['from_node'], cx['to_node']
         try:
-            g.add_edge(nodes[from_node], nodes[to_node])
+            if isinstance(nodes[from_node], Fiber): 
+                edge_length = nodes[from_node].params.length
+                print(from_node)
+                print(edge_length)
+            else:
+                edge_length = 0.01
+            g.add_edge(nodes[from_node], nodes[to_node], weight = edge_length)
         except KeyError:
             msg = f'In {__name__} network_from_json function:\n\tcan not find {from_node} or {to_node} defined in {cx}'
             print(msg)
@@ -352,8 +358,12 @@ def add_egress_amplifier(network, node):
                         'tilt_target': 0,
                     })
         network.add_node(amp)
-        network.add_edge(node, amp)
-        network.add_edge(amp, next_node)
+        if isinstance(node,Fiber):
+            edgeweight = node.params.length
+        else:
+            edgeweight = 0.01
+        network.add_edge(node, amp, weight = edgeweight)
+        network.add_edge(amp, next_node, weight = 0.01)
 
 
 def calculate_new_length(fiber_length, bounds, target_length):
@@ -414,9 +424,17 @@ def split_fiber(network, fiber, bounds, target_length, equipment):
                             }
                           },
                           params = fiber_params)
-        network.add_edge(prev_node, new_span)
+        if isinstance(prev_node,Fiber):
+            edgeweight = prev_node.params.length
+        else:
+            edgeweight = 0.01
+        network.add_edge(prev_node, new_span, weight = edgeweight)
         prev_node = new_span
-    network.add_edge(prev_node, next_node)
+    if isinstance(prev_node,Fiber):
+        edgeweight = prev_node.params.length
+    else:
+        edgeweight = 0.01    
+    network.add_edge(prev_node, next_node, weight = edgeweight)
 
 def add_connector_loss(fibers, con_in, con_out, EOL):
     for fiber in fibers:

--- a/gnpy/core/network.py
+++ b/gnpy/core/network.py
@@ -68,8 +68,8 @@ def network_from_json(json_data, equipment):
         try:
             if isinstance(nodes[from_node], Fiber): 
                 edge_length = nodes[from_node].params.length
-                print(from_node)
-                print(edge_length)
+                # print(from_node)
+                # print(edge_length)
             else:
                 edge_length = 0.01
             g.add_edge(nodes[from_node], nodes[to_node], weight = edge_length)

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -18,7 +18,8 @@ See: draft-ietf-teas-yang-path-computation-01.txt
 from sys import exit
 from collections import namedtuple
 from logging import getLogger, basicConfig, CRITICAL, DEBUG, INFO
-from networkx import (dijkstra_path, NetworkXNoPath, all_simple_paths)
+from networkx import (dijkstra_path, NetworkXNoPath, all_simple_paths,shortest_path_length)
+from networkx import DiGraph
 from networkx.utils import pairwise 
 from numpy import mean
 from gnpy.core.service_sheet import convert_service_sheet, Request_element, Element
@@ -291,7 +292,15 @@ def compute_constrained_path(network, req):
 
     if len(nodes_list) == 1  :
         try :
-            total_path = dijkstra_path(network, source, destination)
+            total_path = dijkstra_path(network, source, destination, weight = 'weight')
+            # print('checking edges length is correct')
+            # print(shortest_path_length(network,source,destination))
+            # print(shortest_path_length(network,source,destination,weight ='weight'))
+            # s = total_path[0]
+            # for e in total_path[1:]:
+            #     print(s.uid)
+            #     print(network.get_edge_data(s,e))
+            #     s = e
         except NetworkXNoPath:
             msg = f'\x1b[1;33;40m'+f'Request {req.request_id} could not find a path from {source.uid} to node : {destination.uid} in network topology'+ '\x1b[0m'
             logger.critical(msg)
@@ -313,7 +322,7 @@ def compute_constrained_path(network, req):
             if req.loose_list[req.nodes_list.index(n)] == 'loose':
                 print(f'\x1b[1;33;40m'+f'Request {req.request_id} could not find a path crossing {nodes_list} in network topology'+ '\x1b[0m')
                 print(f'constraint ignored')
-                total_path = dijkstra_path(network, source, destination)
+                total_path = dijkstra_path(network, source, destination, weight = 'weight')
             else:
                 msg = f'\x1b[1;33;40m'+f'Request {req.request_id} could not find a path crossing {nodes_list}.\nNo path computed'+ '\x1b[0m'
                 logger.critical(msg)
@@ -818,7 +827,7 @@ def find_reversed_path(p,network) :
     destination = p[0]
     total_path = [source]
     for node in reversed_roadm_path :
-        total_path.extend(dijkstra_path(network, source, node)[1:])
+        total_path.extend(dijkstra_path(network, source, node, weight = 'weight')[1:])
         source = node
     total_path.append(destination)
     return total_path

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -19,7 +19,6 @@ from sys import exit
 from collections import namedtuple
 from logging import getLogger, basicConfig, CRITICAL, DEBUG, INFO
 from networkx import (dijkstra_path, NetworkXNoPath, all_simple_paths,shortest_path_length)
-from networkx import DiGraph
 from networkx.utils import pairwise 
 from numpy import mean
 from gnpy.core.service_sheet import convert_service_sheet, Request_element, Element
@@ -314,9 +313,10 @@ def compute_constrained_path(network, req):
             if ispart(nodes_list, p) :
                 # print(f'selection{[el.uid for el in p if el in roadm]}')
                 candidate.append(p)
-        # select the shortest path (in nb of hops)
+        # select the shortest path (in nb of hops) -> changed to shortest path in km length
         if len(candidate)>0 :
-            candidate.sort(key=lambda x: len(x))
+            # candidate.sort(key=lambda x: len(x))
+            candidate.sort(key=lambda x: sum(network.get_edge_data(x[i],x[i+1])['weight'] for i in range(len(x)-2)))
             total_path = candidate[0]
         else:
             if req.loose_list[req.nodes_list.index(n)] == 'loose':
@@ -613,8 +613,10 @@ def compute_path_dsjctn(network, equipment, pathreqlist, disjunctions_list):
             source=next(el for el in network.nodes() if el.uid == pathreq.source),\
             target=next(el for el in network.nodes() if el.uid == pathreq.destination),\
             cutoff=80))
-        # sort them
-        all_simp_pths = sorted(all_simp_pths, key=lambda path: len(path))
+        # sort them in km length instead of hop
+        # all_simp_pths = sorted(all_simp_pths, key=lambda path: len(path))
+        all_simp_pths = sorted(all_simp_pths, key=lambda \
+            x: sum(network.get_edge_data(x[i],x[i+1])['weight'] for i in range(len(x)-2)))
         # reversed direction paths required to check disjunction on both direction
         all_simp_pths_reversed = []
         for pth in all_simp_pths:


### PR DESCRIPTION
Could you please have a look on this work ?
I have been requested several time to provide path computation on the length (km) basis instead of hop.
Here is what I propose to integrate this: 
I have added weigths on network edge in order to compute shortest path in length (km) and not in hop. 
- dijkstra_path with weight attribute
- sort all_simple_paths results as a function of paths' length instead of hop

Note that the feature only works with updated Networkx module. I have not made this change optional since in optical networks length is more relevant than hops.
