### PR TITLE
Add all missing authors and sync the two lists of contributors

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,16 +6,24 @@ To learn how to contribute, please see CONTRIBUTING.md
 (*in alphabetical order*)
 
 - Alessio Ferrari (Politecnico di Torino) <alessio.ferrari@polito.it>
+- Anders Lindgren (Telia Company) <Anders.X.Lindgren@teliacompany.com>
+- Andrea d'Amico (Politecnico di Torino) <andrea.damico@polito.it>
 - Brian Taylor (Facebook) <briantaylor@fb.com>
 - David Boertjes (Ciena) <dboertje@ciena.com>
+- Diego Landa (Facebook) <dlanda@fb.com>
 - Esther Le Rouzic (Orange) <esther.lerouzic@orange.com>
 - Gabriele Galimberti (Cisco) <ggalimbe@cisco.com>
 - Gert Grammel (Juniper Networks) <ggrammel@juniper.net>
 - Gilad Goldfarb (Facebook) <giladg@fb.com>
 - James Powell (Telecom Infra Project) <james.powell@telecominfraproject.com>
+- Jan Kundrát (Telecom Infra Project) <jan.kundrat@telecominfraproject.com>
 - Jeanluc Augé (Orange) <jeanluc.auge@orange.com>
 - Jonas Mårtensson (RISE) <jonas.martensson@ri.se>
 - Mattia Cantono (Politecnico di Torino) <mattia.cantono@polito.it>
+- Miguel Garrich (University Catalunya) <miquel.garrich@upct.es>
+- Raj Nagarajan (Lumentum) <raj.nagarajan@lumentum.com>
 - Roberts Miculens (Lattelecom) <roberts.miculens@lattelecom.lv>
+- Shengxiang Zhu (University of Arizona) <szhu@email.arizona.edu>
+- Stefan Melin (Telia Company) <Stefan.Melin@teliacompany.com>
 - Vittorio Curri (Politecnico di Torino) <vittorio.curri@polito.it>
 - Xufeng Liu (Jabil) <xufeng_liu@jabil.com>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,8 @@ Contributors in alphabetical order
 +----------+------------+-----------------------+--------------------------------------+
 | David    | Boertjes   | Ciena                 | dboertje@ciena.com                   |
 +----------+------------+-----------------------+--------------------------------------+
+| Diego    | Landa      | Facebook              | dlanda@fb.com                        |
++----------+------------+-----------------------+--------------------------------------+
 | Esther   | Le Rouzic  | Orange                | esther.lerouzic@orange.com           |
 +----------+------------+-----------------------+--------------------------------------+
 | Gabriele | Galimberti | Cisco                 | ggalimbe@cisco.com                   |
@@ -61,19 +63,27 @@ Contributors in alphabetical order
 +----------+------------+-----------------------+--------------------------------------+
 | James    | Powell     | Telecom Infra Project | james.powell@telecominfraproject.com |
 +----------+------------+-----------------------+--------------------------------------+
-| Jeanluc  | Auge       | Orange                | jeanluc.auge@orange.com              |
+| Jan      | Kundrát    | Telecom Infra Project | jan.kundrat@telecominfraproject.com  |
 +----------+------------+-----------------------+--------------------------------------+
-| Jonas    | Martensson | RISE Research Sweden  | jonas.martensson@ri.se               |
+| Jeanluc  | Augé       | Orange                | jeanluc.auge@orange.com              |
++----------+------------+-----------------------+--------------------------------------+
+| Jonas    | Mårtensson | RISE Research Sweden  | jonas.martensson@ri.se               |
 +----------+------------+-----------------------+--------------------------------------+
 | Mattia   | Cantono    | Politecnico di Torino | mattia.cantono@polito.it             |
 +----------+------------+-----------------------+--------------------------------------+
 | Miguel   | Garrich    | University Catalunya  | miquel.garrich@upct.es               |
 +----------+------------+-----------------------+--------------------------------------+
-| Stefan   | Melin      | Telia Company         | Stefan.Melin@teliacompany.com        |
-+----------+------------+-----------------------+--------------------------------------+
 | Raj      | Nagarajan  | Lumentum              | raj.nagarajan@lumentum.com           |
 +----------+------------+-----------------------+--------------------------------------+
+| Roberts  | Miculens   | Lattelecom            | roberts.miculens@lattelecom.lv       |
++----------+------------+-----------------------+--------------------------------------+
+| Shengxiang | Zhu      | University of Arizona | szhu@email.arizona.edu               |
++----------+------------+-----------------------+--------------------------------------+
+| Stefan   | Melin      | Telia Company         | Stefan.Melin@teliacompany.com        |
++----------+------------+-----------------------+--------------------------------------+
 | Vittorio | Curri      | Politecnico di Torino | vittorio.curri@polito.it             |
++----------+------------+-----------------------+--------------------------------------+
+| Xufeng   | Liu        | Jabil                 | xufeng_liu@jabil.com                 |
 +----------+------------+-----------------------+--------------------------------------+
 
 --------------


### PR DESCRIPTION
These two lists were not synced with each other, and some contributors whose commits have been merged in git were missing. The resulting list is a bit longer because not everybody who contributes does that strictly via commits pushed to GitHub.

Dear previously unlisted contributos (@diegolaunch , @MiquelGA , @szhu3210 ), are you OK with being listed here?