### PR TITLE
tests: re-enable warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,1 +1,2 @@
 [pytest]
+addopts = --doctest-modules

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,1 @@
 [pytest]
-addopts = -p no:warnings

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ latexcodec==1.0.5
 MarkupSafe==1.0
 matplotlib==3.0.0
 more-itertools==4.3.0
-networkx==2.2
+networkx==2.3
 numpy==1.15.2
 oset==0.1.3
 packaging==18.0
@@ -41,4 +41,4 @@ sphinxcontrib-bibtex==0.4.0
 sphinxcontrib-websupport==1.1.0
 toml==0.10.0
 urllib3==1.23
-xlrd==1.1.0
+xlrd==1.2.0


### PR DESCRIPTION
For some reason, warnings were disabled in commit 07de78c, but it is not clear to me what the purpose was back then. It passes without warnings locally, and I think that warnings are useful in general, so let's give the CI a try.