### PR TITLE
CI: Disable Codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
The results are still perfectly visible within the *Checks* tab, so let's cut the comment spam a little bit.

I've already done the same for lgtm.com; for that app, it's done in their service's configuration within the web app.