### PR TITLE
docs: Fix rendering of the SpectralInformation docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -422,7 +422,7 @@ one power/channel definition.
 +----------------------+-----------+-------------------------------------------+
 | field                |   type    | description                               |
 +======================+===========+===========================================+
-| ``f_min``,           | (number)  | In Hz. Carrier min max excursion.          |
+| ``f_min``,           | (number)  | In Hz. Carrier min max excursion.         |
 | ``f_max``            |           |                                           |
 +----------------------+-----------+-------------------------------------------+
 | ``baud_rate``        | (number)  | In Hz. Simulated baud rate.               |


### PR DESCRIPTION
Due to a misaligned `|`, the table was not rendered at all in the GitHub overview.

Thanks to @ggrammel for catching this in his brownfield doc.