### PR TITLE
correct test and example files with direct Trx reception

### DIFF
--- a/examples/edfa_example_network.json
+++ b/examples/edfa_example_network.json
@@ -50,6 +50,21 @@
             }
         },
         {
+            "uid": "Att_B",
+            "type": "Fused",
+            "params":{
+                "loss":16
+            },
+            "metadata": {
+                "location": {
+                  "latitude": 2.0,
+                  "longitude": 0.0,
+                  "city": "B",
+                  "region": ""
+                }
+            }
+        },        
+        {
             "uid": "Site_B",
             "type": "Transceiver",
             "metadata": {
@@ -73,6 +88,10 @@
         },
         {
             "from_node": "Edfa1",
+            "to_node": "Att_B"
+        },
+        {
+            "from_node": "Att_B",            
             "to_node": "Site_B"
         }
 

--- a/gnpy/core/network.py
+++ b/gnpy/core/network.py
@@ -222,7 +222,9 @@ def target_power(network, node, equipment): #get_fiber_dp
 
     if isinstance(node, Roadm):
         dp = 0
-
+    elif isinstance(node, Transceiver):
+        # limit power on a transceiver
+        dp = -15
     return dp
 
 def prev_node_generator(network, node):

--- a/tests/LinkforTest.json
+++ b/tests/LinkforTest.json
@@ -205,6 +205,36 @@
                     "longitude": 0
                 }
             }
+        },
+        {
+        "uid": "Att_B",
+        "type": "Fused",
+        "params":{
+            "loss":16
+        },
+        "metadata": {
+            "location": {
+              "latitude": 2.0,
+              "longitude": 1.0,
+              "city": "B",
+              "region": ""
+                }
+            }
+        },
+        {
+        "uid": "Att_F",
+        "type": "Fused",
+        "params":{
+            "loss":16
+        },
+        "metadata": {
+            "location": {
+              "latitude": 2.0,
+              "longitude": 1.0,
+              "city": "B",
+              "region": ""
+                }
+            }
         }
 
   ],
@@ -247,6 +277,10 @@
     },
     {
       "from_node": "Edfa5",
+      "to_node": "Att_F"
+    },
+    {
+      "from_node": "Att_F",
       "to_node": "trx F"
     },
     {
@@ -255,6 +289,10 @@
     },
     {
       "from_node": "Edfa1",
+      "to_node": "Att_B"
+    },
+    {
+      "from_node": "Att_B",
       "to_node": "trx B"
     }
   ]

--- a/tests/data/test_network.json
+++ b/tests/data/test_network.json
@@ -77,7 +77,22 @@
                     "longitude": 0
                 }
             }
-        },   
+        },
+        {
+        "uid": "Att_B",
+        "type": "Fused",
+        "params":{
+            "loss":16
+        }, 
+        "metadata": {
+            "location": {
+              "latitude": 2.0,
+              "longitude": 1.0,
+              "city": "Corlay",
+              "region": "RLD"
+                }
+            }
+        },           
         {
             "uid": "Site_B",
             "type": "Transceiver",
@@ -110,6 +125,10 @@
         },        
         {
             "from_node": "Edfa2",
+            "to_node": "Att_B"
+        },
+        {
+            "from_node": "Att_B",
             "to_node": "Site_B"
         }
 


### PR DESCRIPTION
adding  -15 differential per target on receiver instead of 0
and adding attenuator in front of receivers in example networks
and test network, to keep same performances as before this change

Signed-off-by: EstherLerouzic <esther.lerouzic@orange.com>