### PR TITLE
Do not mix THz and Hz

### DIFF
--- a/gnpy/core/elements.py
+++ b/gnpy/core/elements.py
@@ -573,7 +573,7 @@ class Edfa(Node):
                 self.channel_freq, self.nf, self.interpol_dgt and self.interpol_gain_ripple
         """
         # TODO|jla: read amplifier actual frequencies from additional params in json
-        amplifier_freq = itufl(len(self.params.dgt), self.params.f_min, self.params.f_max) * 1e12 # Hz
+        amplifier_freq = itufl(len(self.params.dgt), self.params.f_min, self.params.f_max) # Hz
         self.channel_freq = frequencies
         self.interpol_dgt = interp(self.channel_freq, amplifier_freq, self.params.dgt)
 


### PR DESCRIPTION
While the `itufl()` function uses THz by default, its values depend on the frequency range that is passed via arguments. In this context, the `f_min` and `f_max` come from the default `SpectralInformation` which is in Hz.

Thanks to @ojnas for reporting this.

fixes #243