### PR TITLE
Use exceptions instead of `sys.exit()` when reporting configuration errors

### DIFF
--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -30,7 +30,7 @@ from gnpy.core.utils import db2lin, lin2db
 from gnpy.core.request import (Path_request, Result_element, compute_constrained_path,
                               propagate, jsontocsv, Disjunction, compute_path_dsjctn, requests_aggregation,
                               propagate_and_optimize_mode)
-from gnpy.core.exceptions import ConfigurationError, EquipmentConfigError
+from gnpy.core.exceptions import ConfigurationError, EquipmentConfigError, NetworkTopologyError
 import gnpy.core.ansi_escapes as ansi_escapes
 from copy import copy, deepcopy
 from textwrap import dedent
@@ -314,6 +314,9 @@ if __name__ == '__main__':
         network = load_network(args.network_filename,equipment)
     except EquipmentConfigError as e:
         print(f'{ansi_escapes.red}Configuration error in the equipment library:{ansi_escapes.reset} {e}')
+        exit(1)
+    except NetworkTopologyError as e:
+        print(f'{ansi_escapes.red}Invalid network definition:{ansi_escapes.reset} {e}')
         exit(1)
     except ConfigurationError as e:
         print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')

--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -30,7 +30,7 @@ from gnpy.core.utils import db2lin, lin2db
 from gnpy.core.request import (Path_request, Result_element, compute_constrained_path,
                               propagate, jsontocsv, Disjunction, compute_path_dsjctn, requests_aggregation,
                               propagate_and_optimize_mode)
-from gnpy.core.exceptions import ConfigurationError
+from gnpy.core.exceptions import ConfigurationError, EquipmentConfigError
 import gnpy.core.ansi_escapes as ansi_escapes
 from copy import copy, deepcopy
 from textwrap import dedent
@@ -312,6 +312,9 @@ if __name__ == '__main__':
         data = load_requests(args.service_filename,args.eqpt_filename)
         equipment = load_equipment(args.eqpt_filename)
         network = load_network(args.network_filename,equipment)
+    except EquipmentConfigError as e:
+        print(f'{ansi_escapes.red}Configuration error in the equipment library:{ansi_escapes.reset} {e}')
+        exit(1)
     except ConfigurationError as e:
         print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')
         exit(1)

--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -31,6 +31,7 @@ from gnpy.core.request import (Path_request, Result_element, compute_constrained
                               propagate, jsontocsv, Disjunction, compute_path_dsjctn, requests_aggregation,
                               propagate_and_optimize_mode)
 from gnpy.core.exceptions import ConfigurationError
+import gnpy.core.ansi_escapes as ansi_escapes
 from copy import copy, deepcopy
 from textwrap import dedent
 from math import ceil
@@ -312,7 +313,7 @@ if __name__ == '__main__':
         equipment = load_equipment(args.eqpt_filename)
         network = load_network(args.network_filename,equipment)
     except ConfigurationError as e:
-        print('\x1b[1;31;40m' + 'Configuration error:' + '\x1b[0m' + f' {e}')
+        print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')
         exit(1)
 
     # Build the network once using the default power defined in SI in eqpt config

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -27,6 +27,7 @@ from gnpy.core.elements import Transceiver, Fiber, Edfa, Roadm
 from gnpy.core.info import create_input_spectral_information, SpectralInformation, Channel, Power, Pref
 from gnpy.core.request import Path_request, RequestParams, compute_constrained_path, propagate2
 from gnpy.core.exceptions import ConfigurationError
+import gnpy.core.ansi_escapes as ansi_escapes
 
 logger = getLogger(__name__)
 
@@ -201,7 +202,7 @@ if __name__ == '__main__':
         equipment = load_equipment(args.equipment)
         network = load_network(args.filename, equipment, args.names_matching)
     except ConfigurationError as e:
-        print('\x1b[1;31;40m' + 'Configuration error:' + '\x1b[0m' + f' {e}')
+        print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')
         exit(1)
 
     if args.plot:

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -26,6 +26,7 @@ from gnpy.core.network import load_network, build_network, save_network
 from gnpy.core.elements import Transceiver, Fiber, Edfa, Roadm
 from gnpy.core.info import create_input_spectral_information, SpectralInformation, Channel, Power, Pref
 from gnpy.core.request import Path_request, RequestParams, compute_constrained_path, propagate2
+from gnpy.core.exceptions import ConfigurationError
 
 logger = getLogger(__name__)
 
@@ -196,8 +197,12 @@ if __name__ == '__main__':
     args = parser.parse_args()
     basicConfig(level={0: ERROR, 1: INFO, 2: DEBUG}.get(args.verbose, DEBUG))
 
-    equipment = load_equipment(args.equipment)
-    network = load_network(args.filename, equipment, args.names_matching)
+    try:
+        equipment = load_equipment(args.equipment)
+        network = load_network(args.filename, equipment, args.names_matching)
+    except ConfigurationError as e:
+        print('\x1b[1;31;40m' + 'Configuration error:' + '\x1b[0m' + f' {e}')
+        exit(1)
 
     if args.plot:
         plot_baseline(network)

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -26,7 +26,7 @@ from gnpy.core.network import load_network, build_network, save_network
 from gnpy.core.elements import Transceiver, Fiber, Edfa, Roadm
 from gnpy.core.info import create_input_spectral_information, SpectralInformation, Channel, Power, Pref
 from gnpy.core.request import Path_request, RequestParams, compute_constrained_path, propagate2
-from gnpy.core.exceptions import ConfigurationError
+from gnpy.core.exceptions import ConfigurationError, EquipmentConfigError
 import gnpy.core.ansi_escapes as ansi_escapes
 
 logger = getLogger(__name__)
@@ -201,6 +201,9 @@ if __name__ == '__main__':
     try:
         equipment = load_equipment(args.equipment)
         network = load_network(args.filename, equipment, args.names_matching)
+    except EquipmentConfigError as e:
+        print(f'{ansi_escapes.red}Configuration error in the equipment library:{ansi_escapes.reset} {e}')
+        exit(1)
     except ConfigurationError as e:
         print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')
         exit(1)

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -26,7 +26,7 @@ from gnpy.core.network import load_network, build_network, save_network
 from gnpy.core.elements import Transceiver, Fiber, Edfa, Roadm
 from gnpy.core.info import create_input_spectral_information, SpectralInformation, Channel, Power, Pref
 from gnpy.core.request import Path_request, RequestParams, compute_constrained_path, propagate2
-from gnpy.core.exceptions import ConfigurationError, EquipmentConfigError
+from gnpy.core.exceptions import ConfigurationError, EquipmentConfigError, NetworkTopologyError
 import gnpy.core.ansi_escapes as ansi_escapes
 
 logger = getLogger(__name__)
@@ -203,6 +203,9 @@ if __name__ == '__main__':
         network = load_network(args.filename, equipment, args.names_matching)
     except EquipmentConfigError as e:
         print(f'{ansi_escapes.red}Configuration error in the equipment library:{ansi_escapes.reset} {e}')
+        exit(1)
+    except NetworkTopologyError as e:
+        print(f'{ansi_escapes.red}Invalid network definition:{ansi_escapes.reset} {e}')
         exit(1)
     except ConfigurationError as e:
         print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')

--- a/gnpy/core/ansi_escapes.py
+++ b/gnpy/core/ansi_escapes.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+'''
+gnpy.core.ansi_escapes
+======================
+
+A random subset of ANSI terminal escape codes for colored messages
+'''
+
+red = '\x1b[1;31;40m'
+reset = '\x1b[0m'

--- a/gnpy/core/elements.py
+++ b/gnpy/core/elements.py
@@ -624,14 +624,8 @@ class Edfa(Node):
             nf_avg = pin_ch - polyval(nf_model.nf_coef, pin_ch) + 58
         elif type_def == 'advanced_model':
             nf_avg = polyval(nf_fit_coeff, -dg)
-        else :
-            print(
-                f'\x1b[1;31;40m'\
-                + f'CRITICAL: unrecognized type def _{self.params.type_def}_\n\
-                    => please check eqpt_config.json'\
-                + '\x1b[0m'
-                )                        
-            exit()            
+        else:
+            assert False, "Unrecognized amplifier type, this should have been checked by the JSON loader"
         return nf_avg+pad, pad
 
     def _calc_nf(self, avg = False):

--- a/gnpy/core/equipment.py
+++ b/gnpy/core/equipment.py
@@ -9,7 +9,6 @@ This module contains functionality for specifying equipment.
 '''
 
 from numpy import clip, polyval
-from sys import exit
 from operator import itemgetter
 from math import isclose
 from pathlib import Path
@@ -17,6 +16,7 @@ from json import load
 from gnpy.core.utils import lin2db, db2lin, load_json
 from collections import namedtuple
 from gnpy.core.elements import Edfa
+from gnpy.core.exceptions import ConfigurationError
 import time
 
 Model_vg = namedtuple('Model_vg', 'nf1 nf2 delta_p')
@@ -142,8 +142,7 @@ class Amp(common):
             try:
                 nf0 = kwargs.pop('nf0')
             except KeyError: #nf0 is expected for a fixed gain amp
-                print(f'missing nf0 value input for amplifier: {type_variety} in eqpt_config.json')
-                exit()
+                raise ConfigurationError(f'missing nf0 value input for amplifier: {type_variety} in equipment config')
             for k in ('nf_min', 'nf_max'):
                 try:
                     del kwargs[k]
@@ -158,8 +157,7 @@ class Amp(common):
                 nf_min = kwargs.pop('nf_min')
                 nf_max = kwargs.pop('nf_max')
             except KeyError:
-                print(f'missing nf_min/max value input for amplifier: {type_variety} in eqpt_config.json')
-                exit()
+                raise ConfigurationError(f'missing nf_min or nf_max value input for amplifier: {type_variety} in equipment config')
             try: #remove all remaining nf inputs
                 del kwargs['nf0']
             except KeyError: pass #nf0 is not needed for variable gain amp
@@ -169,16 +167,14 @@ class Amp(common):
             try:
                 nf_coef = kwargs.pop('nf_coef')
             except KeyError: #nf_coef is expected for openroadm amp
-                print(f'missing nf_coef input for amplifier: {type_variety} in eqpt_config.json')
-                exit()
+                raise ConfigurationError(f'missing nf_coef input for amplifier: {type_variety} in equipment config')
             nf_def = Model_openroadm(nf_coef)
         elif type_def == 'dual_stage':
             try: #nf_ram and gain_ram are expected for a hybrid amp
                 preamp_variety = kwargs.pop('preamp_variety')
                 booster_variety = kwargs.pop('booster_variety')
             except KeyError:
-                print(f'missing preamp/booster variety input for amplifier: {type_variety} in eqpt_config.json')
-                exit()
+                raise ConfigurationError(f'missing preamp/booster variety input for amplifier: {type_variety} in equipment config')
             dual_stage_def = Model_dual_stage(preamp_variety, booster_variety)
 
         with open(config, encoding='utf-8') as f:
@@ -190,11 +186,9 @@ class Amp(common):
 
 def nf_model(type_variety, gain_min, gain_max, nf_min, nf_max):
     if nf_min < -10:
-        print(f'Invalid nf_min value {nf_min!r} for amplifier {type_variety}')
-        exit()
+        raise ConfigurationError(f'Invalid nf_min value {nf_min!r} for amplifier {type_variety}')
     if nf_max < -10:
-        print(f'Invalid nf_max value {nf_max!r} for amplifier {type_variety}')
-        exit()
+        raise ConfigurationError(f'Invalid nf_max value {nf_max!r} for amplifier {type_variety}')
 
     # NF estimation model based on nf_min and nf_max
     # delta_p:  max power dB difference between first and second stage coils
@@ -209,8 +203,7 @@ def nf_model(type_variety, gain_min, gain_max, nf_min, nf_max):
     nf1 = lin2db(db2lin(nf_min) - db2lin(nf2)/db2lin(g1a_max))
 
     if nf1 < 4:
-        print(f'First coil value too low {nf1} for amplifier {type_variety}')
-        exit()
+        raise ConfigurationError(f'First coil value too low {nf1} for amplifier {type_variety}')
 
     # Check 1 dB < delta_p < 6 dB to ensure nf_min and nf_max values make sense.
     # There shouldn't be high nf differences between the two coils:
@@ -222,20 +215,17 @@ def nf_model(type_variety, gain_min, gain_max, nf_min, nf_max):
         delta_p = gain_max - g1a_max
         g1a_min = gain_min - (gain_max-gain_min) - delta_p
         if not 1 < delta_p < 11:
-            print(f'Computed \N{greek capital letter delta}P invalid \
+            raise ConfigurationError(f'Computed \N{greek capital letter delta}P invalid \
                 \n 1st coil vs 2nd coil calculated DeltaP {delta_p:.2f} for \
                 \n amplifier {type_variety} is not valid: revise inputs \
                 \n calculated 1st coil NF = {nf1:.2f}, 2nd coil NF = {nf2:.2f}')
-            exit()
     # Check calculated values for nf1 and nf2
     calc_nf_min = lin2db(db2lin(nf1) + db2lin(nf2)/db2lin(g1a_max))
     if not isclose(nf_min, calc_nf_min, abs_tol=0.01):
-        print(f'nf_min does not match calc_nf_min, {nf_min} vs {calc_nf_min} for amp {type_variety}')
-        exit()
+        raise ConfigurationError(f'nf_min does not match calc_nf_min, {nf_min} vs {calc_nf_min} for amp {type_variety}')
     calc_nf_max = lin2db(db2lin(nf1) + db2lin(nf2)/db2lin(g1a_min))
     if not isclose(nf_max, calc_nf_max, abs_tol=0.01):
-        print(f'nf_max does not match calc_nf_max, {nf_max} vs {calc_nf_max} for amp {type_variety}')
-        exit()
+        raise ConfigurationError(f'nf_max does not match calc_nf_max, {nf_max} vs {calc_nf_max} for amp {type_variety}')
 
     return nf1, nf2, delta_p
 
@@ -270,10 +260,8 @@ def trx_mode_params(equipment, trx_type_variety='', trx_mode='', error_message=F
             trx_params = {**mode_params}
             # sanity check: spacing baudrate must be smaller than min spacing
             if trx_params['baud_rate'] > trx_params['min_spacing'] :
-                msg = f'Inconsistency in equipment library:\n Transpoder "{trx_type_variety}" mode "{trx_params["format"]}" '+\
-                    f'has baud rate: {trx_params["baud_rate"]*1e-9} GHz greater than min_spacing {trx_params["min_spacing"]*1e-9}.'
-                print(msg)
-                exit()
+                raise ConfigurationError(f'Inconsistency in equipment library:\n Transpoder "{trx_type_variety}" mode "{trx_params["format"]}" '+\
+                    f'has baud rate: {trx_params["baud_rate"]*1e-9} GHz greater than min_spacing {trx_params["min_spacing"]*1e-9}.')
         else:
             mode_params = {"format": "undetermined",
                        "baud_rate": None,
@@ -293,9 +281,7 @@ def trx_mode_params(equipment, trx_type_variety='', trx_mode='', error_message=F
         # print(f'spacing {temp}')
     except StopIteration :
         if error_message:
-            print(f'could not find tsp : {trx_type_variety} with mode: {trx_mode} in eqpt library')
-            print('Computation stopped.')
-            exit()
+            raise ConfigurationError(f'Computation stoped: could not find tsp : {trx_type_variety} with mode: {trx_mode} in eqpt library')
         else:
             # default transponder charcteristics
             # mainly used with transmission_main_example.py
@@ -356,13 +342,7 @@ def update_dual_stage(equipment):
             edfa.p_max = edfa_booster.p_max
             edfa.gain_flatmax = edfa_booster.gain_flatmax + edfa_preamp.gain_flatmax
             if edfa.gain_min < edfa_preamp.gain_min:
-                print(
-                    f'\x1b[1;31;40m'\
-                    + f'CRITICAL: dual stage {edfa.type_variety} min gain is lower than its preamp min gain\
-                        => please increase its min gain in eqpt_config.json'\
-                    + '\x1b[0m'
-                    )                        
-                exit()
+                raise ConfigurationError(f'Dual stage {edfa.type_variety} min gain is lower than its preamp min gain')
     return equipment
 
 def equipment_from_json(json_data, filename):

--- a/gnpy/core/equipment.py
+++ b/gnpy/core/equipment.py
@@ -16,7 +16,7 @@ from json import load
 from gnpy.core.utils import lin2db, db2lin, load_json
 from collections import namedtuple
 from gnpy.core.elements import Edfa
-from gnpy.core.exceptions import ConfigurationError
+from gnpy.core.exceptions import EquipmentConfigError
 import time
 
 Model_vg = namedtuple('Model_vg', 'nf1 nf2 delta_p')
@@ -142,7 +142,7 @@ class Amp(common):
             try:
                 nf0 = kwargs.pop('nf0')
             except KeyError: #nf0 is expected for a fixed gain amp
-                raise ConfigurationError(f'missing nf0 value input for amplifier: {type_variety} in equipment config')
+                raise EquipmentConfigError(f'missing nf0 value input for amplifier: {type_variety} in equipment config')
             for k in ('nf_min', 'nf_max'):
                 try:
                     del kwargs[k]
@@ -157,7 +157,7 @@ class Amp(common):
                 nf_min = kwargs.pop('nf_min')
                 nf_max = kwargs.pop('nf_max')
             except KeyError:
-                raise ConfigurationError(f'missing nf_min or nf_max value input for amplifier: {type_variety} in equipment config')
+                raise EquipmentConfigError(f'missing nf_min or nf_max value input for amplifier: {type_variety} in equipment config')
             try: #remove all remaining nf inputs
                 del kwargs['nf0']
             except KeyError: pass #nf0 is not needed for variable gain amp
@@ -167,14 +167,14 @@ class Amp(common):
             try:
                 nf_coef = kwargs.pop('nf_coef')
             except KeyError: #nf_coef is expected for openroadm amp
-                raise ConfigurationError(f'missing nf_coef input for amplifier: {type_variety} in equipment config')
+                raise EquipmentConfigError(f'missing nf_coef input for amplifier: {type_variety} in equipment config')
             nf_def = Model_openroadm(nf_coef)
         elif type_def == 'dual_stage':
             try: #nf_ram and gain_ram are expected for a hybrid amp
                 preamp_variety = kwargs.pop('preamp_variety')
                 booster_variety = kwargs.pop('booster_variety')
             except KeyError:
-                raise ConfigurationError(f'missing preamp/booster variety input for amplifier: {type_variety} in equipment config')
+                raise EquipmentConfigError(f'missing preamp/booster variety input for amplifier: {type_variety} in equipment config')
             dual_stage_def = Model_dual_stage(preamp_variety, booster_variety)
 
         with open(config, encoding='utf-8') as f:
@@ -186,9 +186,9 @@ class Amp(common):
 
 def nf_model(type_variety, gain_min, gain_max, nf_min, nf_max):
     if nf_min < -10:
-        raise ConfigurationError(f'Invalid nf_min value {nf_min!r} for amplifier {type_variety}')
+        raise EquipmentConfigError(f'Invalid nf_min value {nf_min!r} for amplifier {type_variety}')
     if nf_max < -10:
-        raise ConfigurationError(f'Invalid nf_max value {nf_max!r} for amplifier {type_variety}')
+        raise EquipmentConfigError(f'Invalid nf_max value {nf_max!r} for amplifier {type_variety}')
 
     # NF estimation model based on nf_min and nf_max
     # delta_p:  max power dB difference between first and second stage coils
@@ -203,7 +203,7 @@ def nf_model(type_variety, gain_min, gain_max, nf_min, nf_max):
     nf1 = lin2db(db2lin(nf_min) - db2lin(nf2)/db2lin(g1a_max))
 
     if nf1 < 4:
-        raise ConfigurationError(f'First coil value too low {nf1} for amplifier {type_variety}')
+        raise EquipmentConfigError(f'First coil value too low {nf1} for amplifier {type_variety}')
 
     # Check 1 dB < delta_p < 6 dB to ensure nf_min and nf_max values make sense.
     # There shouldn't be high nf differences between the two coils:
@@ -215,17 +215,17 @@ def nf_model(type_variety, gain_min, gain_max, nf_min, nf_max):
         delta_p = gain_max - g1a_max
         g1a_min = gain_min - (gain_max-gain_min) - delta_p
         if not 1 < delta_p < 11:
-            raise ConfigurationError(f'Computed \N{greek capital letter delta}P invalid \
+            raise EquipmentConfigError(f'Computed \N{greek capital letter delta}P invalid \
                 \n 1st coil vs 2nd coil calculated DeltaP {delta_p:.2f} for \
                 \n amplifier {type_variety} is not valid: revise inputs \
                 \n calculated 1st coil NF = {nf1:.2f}, 2nd coil NF = {nf2:.2f}')
     # Check calculated values for nf1 and nf2
     calc_nf_min = lin2db(db2lin(nf1) + db2lin(nf2)/db2lin(g1a_max))
     if not isclose(nf_min, calc_nf_min, abs_tol=0.01):
-        raise ConfigurationError(f'nf_min does not match calc_nf_min, {nf_min} vs {calc_nf_min} for amp {type_variety}')
+        raise EquipmentConfigError(f'nf_min does not match calc_nf_min, {nf_min} vs {calc_nf_min} for amp {type_variety}')
     calc_nf_max = lin2db(db2lin(nf1) + db2lin(nf2)/db2lin(g1a_min))
     if not isclose(nf_max, calc_nf_max, abs_tol=0.01):
-        raise ConfigurationError(f'nf_max does not match calc_nf_max, {nf_max} vs {calc_nf_max} for amp {type_variety}')
+        raise EquipmentConfigError(f'nf_max does not match calc_nf_max, {nf_max} vs {calc_nf_max} for amp {type_variety}')
 
     return nf1, nf2, delta_p
 
@@ -260,7 +260,7 @@ def trx_mode_params(equipment, trx_type_variety='', trx_mode='', error_message=F
             trx_params = {**mode_params}
             # sanity check: spacing baudrate must be smaller than min spacing
             if trx_params['baud_rate'] > trx_params['min_spacing'] :
-                raise ConfigurationError(f'Inconsistency in equipment library:\n Transpoder "{trx_type_variety}" mode "{trx_params["format"]}" '+\
+                raise EquipmentConfigError(f'Inconsistency in equipment library:\n Transpoder "{trx_type_variety}" mode "{trx_params["format"]}" '+\
                     f'has baud rate: {trx_params["baud_rate"]*1e-9} GHz greater than min_spacing {trx_params["min_spacing"]*1e-9}.')
         else:
             mode_params = {"format": "undetermined",
@@ -281,7 +281,7 @@ def trx_mode_params(equipment, trx_type_variety='', trx_mode='', error_message=F
         # print(f'spacing {temp}')
     except StopIteration :
         if error_message:
-            raise ConfigurationError(f'Computation stoped: could not find tsp : {trx_type_variety} with mode: {trx_mode} in eqpt library')
+            raise EquipmentConfigError(f'Computation stoped: could not find tsp : {trx_type_variety} with mode: {trx_mode} in eqpt library')
         else:
             # default transponder charcteristics
             # mainly used with transmission_main_example.py
@@ -342,7 +342,7 @@ def update_dual_stage(equipment):
             edfa.p_max = edfa_booster.p_max
             edfa.gain_flatmax = edfa_booster.gain_flatmax + edfa_preamp.gain_flatmax
             if edfa.gain_min < edfa_preamp.gain_min:
-                raise ConfigurationError(f'Dual stage {edfa.type_variety} min gain is lower than its preamp min gain')
+                raise EquipmentConfigError(f'Dual stage {edfa.type_variety} min gain is lower than its preamp min gain')
     return equipment
 
 def equipment_from_json(json_data, filename):

--- a/gnpy/core/exceptions.py
+++ b/gnpy/core/exceptions.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+'''
+gnpy.core.exceptions
+====================
+
+Exceptions thrown by other gnpy modules
+'''
+
+
+class ConfigurationError(Exception):
+    '''User-provided configuration contains an error'''

--- a/gnpy/core/exceptions.py
+++ b/gnpy/core/exceptions.py
@@ -11,3 +11,6 @@ Exceptions thrown by other gnpy modules
 
 class ConfigurationError(Exception):
     '''User-provided configuration contains an error'''
+
+class EquipmentConfigError(ConfigurationError):
+    '''Incomplete or wrong configuration within the equipment library'''

--- a/gnpy/core/exceptions.py
+++ b/gnpy/core/exceptions.py
@@ -14,3 +14,6 @@ class ConfigurationError(Exception):
 
 class EquipmentConfigError(ConfigurationError):
     '''Incomplete or wrong configuration within the equipment library'''
+
+class NetworkTopologyError(ConfigurationError):
+    '''Topology of user-provided network is wrong'''

--- a/gnpy/core/network.py
+++ b/gnpy/core/network.py
@@ -157,6 +157,7 @@ def select_edfa(raman_allowed, gain_target, power_target, equipment, uid):
                     to satisfy min gain requirement in node {uid} \
                     please increase span fiber padding')
         else:
+            # TODO: convert to logging
             print(
                 f'\x1b[1;31;40m'\
                 + f'WARNING: target gain in node {uid} is below all available amplifiers min gain: \


### PR DESCRIPTION
The code was originally written with direct `exit()` invocation in order to present nice error messages to the user who is running examples from our `examples/` directory. However, this means that one cannot really use the library *as a library*, handling errors in a completely different manner. As an example, if someone wants to write a PCE server with GNPy for impairment calculation, it is most certainly a wrong thing to do to hard-exit an entire daemon when handling a malformed request.

This patch series therefore introduces some rudimentary exception hierarchy, and then we add some pretty-printers for colorful printing in our examples. It already distinguishes between "equipment library errors" (malformed data) and "network topology errors" (nonsensical topologies).

(My editor apparently decided to strip extra whitespace from some offending lines, which is a pretty standard configuration. Sorry for mixing these up, though.)

Cc: @EstherLerouzic 