### PR TITLE
YANG models for inventory management and topology description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - ./examples/path_requests_run.py
   - ./examples/transmission_main_example.py examples/raman_edfa_example_network.json --sim examples/sim_params.json --show-channels
   - sphinx-build docs/ x-throwaway-location
+  #- yanglint -t config --strict --merge -f xml -D yang/tip-*.yang yang/all.json
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ script:
   - ./examples/transmission_main_example.py examples/raman_edfa_example_network.json --sim examples/sim_params.json --show-channels
   - sphinx-build docs/ x-throwaway-location
   #- yanglint -t config --strict --merge -f xml -D yang/tip-*.yang yang/all.json
+  # ^^ this is with CESNET's libyang. Alternatively, use CZ-NIC's yangson:
+  #- python path/to/yangson/tools/python/mkylib.py yang/ > LIB.json
+  #- yangson -p yang --validate yang/all.json LIB.json
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 jobs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scipy>=1.3.0,<2
 Sphinx>=2.1.1,<3
 sphinxcontrib-bibtex>=0.4.2,<1
 xlrd>=1.2.0,<2
+yangson>=1.3.40,<2

--- a/yang/all.json
+++ b/yang/all.json
@@ -95,5 +95,73 @@
     {
       "type": "Voyager"
     }
-  ]
+  ],
+
+  "ietf-network:networks": {
+    "network": [
+      {
+        "network-id": "TIP OOPT-PSE sample topology",
+        "network-types": {
+          "tip-photonic-topology:photonic-topology": {
+          }
+        },
+        "node": [
+          {
+            "node-id": "trx-1",
+            "tip-photonic-topology:transceiver": {
+              "model": "Voyager"
+            },
+            "tip-photonic-topology:location": {
+              "name": "A"
+            }
+          },
+          {
+            "node-id": "trx-2",
+            "tip-photonic-topology:transceiver": {
+              "model": "Voyager"
+            },
+            "tip-photonic-topology:location": {
+              "name": "B"
+            }
+          },
+          {
+            "node-id": "adfa-A",
+            "tip-photonic-topology:amplifier": {
+              "model": "fixed-22",
+              "gain-target": 19.0,
+              "tilt-target": 10.0
+            }
+          }
+        ],
+        "ietf-network-topology:link": [
+          {
+            "link-id": "fiber trx-1 edfa-1",
+            "source": {
+              "source-node": "trx-1"
+            },
+            "destination": {
+              "dest-node": "edfa-A"
+            },
+            "tip-photonic-topology:fiber": {
+              "type": "SSMF",
+              "length": 60
+            }
+          },
+          {
+            "link-id": "fiber edfa-A trx-2",
+            "source": {
+              "source-node": "edfa-A"
+            },
+            "destination": {
+              "dest-node": "trx-2"
+            },
+            "tip-photonic-topology:fiber": {
+              "type": "SSMF",
+              "length": 50
+            }
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/yang/all.json
+++ b/yang/all.json
@@ -1,0 +1,99 @@
+{
+  "tip-photonic-equipment:amplifier": [
+    {
+      "type": "fixed-27",
+      "polynomial-NF": {
+        "gain-min": 27,
+        "gain-flatmax": 27,
+        "gain-max-extended": 27,
+	"nf-polynomial-coefficients": {
+          "a": 0,
+          "b": 0,
+          "c": 0,
+          "d": 4.9
+	},
+        "max-power-out": 21.9
+      }
+    },
+    {
+      "type": "fixed-22",
+      "polynomial-NF": {
+        "gain-min": 22,
+        "gain-flatmax": 22,
+        "gain-max-extended": 22,
+	"nf-polynomial-coefficients": {
+          "a": 0,
+          "b": 0,
+          "c": 0,
+          "d": 4.8
+	},
+        "max-power-out": 21.9
+      }
+    },
+    {
+      "type": "vg-15-30",
+      "min-max-NF": {
+        "nf-min": 4.9,
+        "nf-max": 12.0,
+        "gain-min": 15,
+        "gain-flatmax": 27,
+        "gain-max-extended": 28,
+        "gain-ripple": [0],
+        "nf-ripple": [0],
+        "dynamic-gain-tilt": [0, 2.4],
+        "max-power-out": 23
+      }
+    },
+    {
+      "type": "vg-10-19",
+      "min-max-NF": {
+        "nf-min": 5.1,
+        "nf-max": 5.8,
+        "gain-min": 10,
+        "gain-flatmax": 17,
+        "gain-max-extended": 20,
+        "gain-ripple": [0],
+        "nf-ripple": [0],
+        "dynamic-gain-tilt": [0, 1.7],
+        "max-power-out": 23
+      }
+    },
+    {
+      "type": "dual--vg-15-30--vg-10-19",
+      "dual-stage": {
+        "preamp": "vg-15-30",
+        "booster": "vg-10-19",
+        "gain-min": 25.0
+      }
+    },
+    {
+      "type": "raman",
+      "raman": {
+        "gain": 12,
+        "nf": 3
+      }
+    }
+  ],
+  "tip-photonic-equipment:fiber": [
+    {
+      "type": "SSMF",
+      "dispersion": 1.67e-05,
+      "gamma": 0.00127
+    },
+    {
+      "type": "NZDF",
+      "dispersion": 0.5e-05,
+      "gamma": 0.00146
+    },
+    {
+      "type": "LOF",
+      "dispersion": 2.2e-05,
+      "gamma": 0.000843
+    }
+  ],
+  "tip-photonic-equipment:transceiver": [
+    {
+      "type": "Voyager"
+    }
+  ]
+}

--- a/yang/all.json
+++ b/yang/all.json
@@ -111,17 +111,15 @@
             "tip-photonic-topology:transceiver": {
               "model": "Voyager"
             },
-            "tip-photonic-topology:location": {
-              "name": "A"
+            "tip-photonic-topology:geo-location": {
+              "latitude": 0,
+              "longitude": 0
             }
           },
           {
             "node-id": "trx-2",
             "tip-photonic-topology:transceiver": {
               "model": "Voyager"
-            },
-            "tip-photonic-topology:location": {
-              "name": "B"
             }
           },
           {

--- a/yang/ietf-geo-location@2019-02-17.yang
+++ b/yang/ietf-geo-location@2019-02-17.yang
@@ -1,0 +1,251 @@
+module ietf-geo-location {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-geo-location";
+  prefix geo;
+  import ietf-yang-types { prefix types; }
+
+  organization
+    "IETF NETMOD Working Group (NETMOD)";
+  contact
+    "Christian Hopps <chopps@chopps.org>";
+
+  // RFC Ed.: replace XXXX with actual RFC number and
+  // remove this note.
+
+  description
+    "This module defines a grouping of a container object for
+     specifying a location on or around an astronomical object (e.g.,
+     The Earth).
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 [RFC2119] [RFC8174] when, and only when,
+     they appear in all capitals, as shown here.
+
+     This version of this YANG module is part of RFC XXXX
+     (https://tools.ietf.org/html/rfcXXXX); see the RFC itself for
+     full legal notices.";
+
+  // RFC Ed.: replace XXXX with actual RFC number and
+  // remove this note.
+
+  revision 2019-02-17 {
+    description "Initial Revision";
+    reference "RFC XXXX: YANG Geo Location";
+  }
+
+  typedef degrees {
+    type decimal64 {
+      fraction-digits 16;
+    }
+    units "decimal degrees";
+    description "Coordinate value.";
+  }
+
+  feature alternate-systems {
+    description
+      "This feature means the device supports specifying locations
+       using alternate systems for reference frames.";
+  }
+
+  grouping geo-location {
+   description
+      "Grouping to identify a location on an astronomical object.";
+
+    container geo-location {
+      description
+        "A location on an astronomical body (e.g., The Earth)
+         somewhere in a universe.";
+
+      container reference-frame {
+        description
+          "The Frame of Reference for the location values.";
+
+        leaf alternate-system {
+          if-feature alternate-systems;
+          type string;
+          description
+            "The system in which the astronomical body and
+             geodetic-datum is defined. Normally, this value is not
+             present and the system is the natural universe; however,
+             when present this value allows for specifying alternate
+             systems (e.g., virtual realities). An alternate-system
+             modifies the definition (but not the type) of the other
+             values in the reference frame.";
+        }
+        leaf astronomical-body {
+          type string {
+            pattern '[ -@\[-\^_-~]*';
+          }
+          default "earth";
+          description
+            "An astronomical body as named by the International
+             Astronomical Union (IAU) or according to the alternate
+             system if specified. Examples include 'sun' (our star),
+             'earth' (our planet), 'moon' (our moon), 'enceladus' (a
+             moon of Saturn), 'ceres' (an asteroid),
+             '67p/churyumov-gerasimenko (a comet). The value should
+             be comprised of all lower case ASCII characters not
+             including control characters (i.e., values 32..64, and
+             91..126). Any preceding 'the' in the name should not
+             be included.";
+        }
+        container geodetic-system {
+          description
+            "The geodetic system of the location data.";
+          leaf geodetic-datum {
+            type string {
+              pattern '[ -@\[-\^_-~]*';
+            }
+            default "wgs-84";
+            description
+              "A geodetic-datum defining the meaning of latitude,
+               longitude and height. The default is 'wgs-84' which is
+               used by the Global Positioning System (GPS). The value
+               SHOULD be comprised of all lower case ASCII characters
+               not including control characters (i.e., values 32..64,
+               and 91..126). The IANA registry further restricts the
+               value by converting all spaces (' ') to dashes ('-')";
+          }
+          leaf coord-accuracy {
+            type decimal64 {
+              fraction-digits 6;
+            }
+            description
+              "The accuracy of the latitude longitude pair. When
+               coord-accuracy is specified it overrides the
+               geodetic-datum implied accuracy. If Cartesian
+               coordinates are in use this accuracy corresponds to
+               the X and Y components";
+          }
+          leaf height-accuracy {
+            type decimal64 {
+              fraction-digits 6;
+            }
+            units "meters";
+            description
+              "The accuracy of height value. When specified it
+               overrides the geodetic-datum implied default. If
+               Cartesian coordinates ar in use this accuracy
+               corresponds to the Z component.";
+          }
+          // May wish to allow for height to be relative.
+          // If so need to decide if we have a boolean (to ground)
+          // or an enumeration (e.g., local ground, sea-floor,
+          // ground floor, containing object, ...) or even allow
+          // for a string for most generic but least portable
+          // comparable
+          // leaf height-relative {
+          // }
+        }
+      }
+      choice location {
+        mandatory true;
+        description
+          "The location data either in lat/long or Cartesian values";
+        case ellipsoid {
+          leaf latitude {
+            type degrees;
+            mandatory true;
+            description
+              "The latitude value on the astronomical body. The
+               definition and precision of this measurement is
+               indicated by the reference-frame value.";
+          }
+          leaf longitude {
+            type degrees;
+            mandatory true;
+            description
+              "The longitude value on the astronomical body. The
+               definition and precision of this measurement is
+               indicated by the reference-frame.";
+          }
+          leaf height {
+            type decimal64 {
+              fraction-digits 6;
+            }
+            units "meters";
+            description
+              "Height from a reference 0 value. The precision and '0'
+               value is defined by the reference-frame.";
+          }
+        }
+        case cartesian {
+          leaf x {
+            type decimal64 {
+              fraction-digits 6;
+            }
+            mandatory true;
+            description
+              "The X value as defined by the reference-frame.";
+          }
+          leaf y {
+            type decimal64 {
+              fraction-digits 6;
+            }
+            mandatory true;
+            description
+              "The Y value as defined by the reference-frame.";
+          }
+          leaf z {
+            type decimal64 {
+              fraction-digits 6;
+            }
+            units "meters";
+            description
+              "The Z value as defined by the reference-frame.";
+          }
+        }
+      }
+      container velocity {
+        description
+          "If the object is in motion the velocity vector describes
+           this motion at the the time given by the timestamp.";
+
+        leaf v-north {
+          type decimal64 {
+            fraction-digits 12;
+          }
+          units "meters per second";
+          description
+            "v-north is the rate of change (i.e., speed) towards
+             truth north as defined by the ~geodetic-system~.";
+        }
+
+        leaf v-east {
+          type decimal64 {
+            fraction-digits 12;
+          }
+          units "meters per second";
+          description
+            "v-east is the rate of change (i.e., speed) perpendicular
+             to truth-north as defined by the ~geodetic-system~.";
+        }
+
+        leaf v-up {
+          type decimal64 {
+            fraction-digits 12;
+          }
+          units "meters per second";
+          description
+            "v-up is the rate of change (i.e., speed) away from the
+             center of mass.";
+        }
+      }
+      leaf timestamp {
+        type types:date-and-time;
+        description "Reference time when location was recorded.";
+      }
+    }
+  }
+}

--- a/yang/ietf-inet-types@2013-07-15.yang
+++ b/yang/ietf-inet-types@2013-07-15.yang
@@ -1,0 +1,458 @@
+module ietf-inet-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+  prefix "inet";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of types related to protocol fields ***/
+
+  typedef ip-version {
+    type enumeration {
+      enum unknown {
+        value "0";
+        description
+         "An unknown or unspecified version of the Internet
+          protocol.";
+      }
+      enum ipv4 {
+        value "1";
+        description
+         "The IPv4 protocol as defined in RFC 791.";
+      }
+      enum ipv6 {
+        value "2";
+        description
+         "The IPv6 protocol as defined in RFC 2460.";
+      }
+    }
+    description
+     "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+    reference
+     "RFC  791: Internet Protocol
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  typedef dscp {
+    type uint8 {
+      range "0..63";
+    }
+    description
+     "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+    reference
+     "RFC 3289: Management Information Base for the Differentiated
+                Services Architecture
+      RFC 2474: Definition of the Differentiated Services Field
+                (DS Field) in the IPv4 and IPv6 Headers
+      RFC 2780: IANA Allocation Guidelines For Values In
+                the Internet Protocol and Related Headers";
+  }
+
+  typedef ipv6-flow-label {
+    type uint32 {
+      range "0..1048575";
+    }
+    description
+     "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+    reference
+     "RFC 3595: Textual Conventions for IPv6 Flow Label
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+  }
+
+  typedef port-number {
+    type uint16 {
+      range "0..65535";
+    }
+    description
+     "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+    reference
+     "RFC  768: User Datagram Protocol
+      RFC  793: Transmission Control Protocol
+      RFC 4960: Stream Control Transmission Protocol
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  /*** collection of types related to autonomous systems ***/
+
+  typedef as-number {
+    type uint32;
+    description
+     "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+    reference
+     "RFC 1930: Guidelines for creation, selection, and registration
+                of an Autonomous System (AS)
+      RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+      RFC 4001: Textual Conventions for Internet Network Addresses
+      RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+                Number Space";
+  }
+
+  /*** collection of types related to IP addresses and hostnames ***/
+
+  typedef ip-address {
+    type union {
+      type inet:ipv4-address;
+      type inet:ipv6-address;
+    }
+    description
+     "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+      + '(%[\p{N}\p{L}]+)?';
+    }
+    description
+      "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+  }
+
+  typedef ipv6-address {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(%[\p{N}\p{L}]+)?';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(%.+)?';
+    }
+    description
+     "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-address-no-zone {
+    type union {
+      type inet:ipv4-address-no-zone;
+      type inet:ipv6-address-no-zone;
+    }
+    description
+     "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address-no-zone {
+    type inet:ipv4-address {
+      pattern '[0-9\.]*';
+    }
+    description
+      "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+  }
+
+  typedef ipv6-address-no-zone {
+    type inet:ipv6-address {
+      pattern '[0-9a-fA-F:\.]*';
+    }
+    description
+      "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-prefix {
+    type union {
+      type inet:ipv4-prefix;
+      type inet:ipv6-prefix;
+    }
+    description
+     "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+  }
+
+  typedef ipv4-prefix {
+    type string {
+      pattern
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))';
+    }
+    description
+     "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+  }
+
+  typedef ipv6-prefix {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(/.+)';
+    }
+
+    description
+     "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+    reference
+     "RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  /*** collection of domain name and URI types ***/
+
+  typedef domain-name {
+    type string {
+      pattern
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'
+      + '|\.';
+      length "1..253";
+    }
+    description
+     "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+    reference
+     "RFC  952: DoD Internet Host Table Specification
+      RFC 1034: Domain Names - Concepts and Facilities
+      RFC 1123: Requirements for Internet Hosts -- Application
+                and Support
+      RFC 2782: A DNS RR for specifying the location of services
+                (DNS SRV)
+      RFC 5890: Internationalized Domain Names in Applications
+                (IDNA): Definitions and Document Framework";
+  }
+
+  typedef host {
+    type union {
+      type inet:ip-address;
+      type inet:domain-name;
+    }
+    description
+     "The host type represents either an IP address or a DNS
+      domain name.";
+  }
+
+  typedef uri {
+    type string;
+    description
+     "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+    reference
+     "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+                Group: Uniform Resource Identifiers (URIs), URLs,
+                and Uniform Resource Names (URNs): Clarifications
+                and Recommendations
+      RFC 5017: MIB Textual Conventions for Uniform Resource
+                Identifiers (URIs)";
+  }
+
+}

--- a/yang/ietf-network-topology@2018-02-26.yang
+++ b/yang/ietf-network-topology@2018-02-26.yang
@@ -1,0 +1,294 @@
+module ietf-network-topology {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network-topology";
+  prefix nt;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-network {
+    prefix nw;
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+
+  description
+    "This module defines a common base model for a network topology,
+     augmenting the base network data model with links to connect
+     nodes, as well as termination points to terminate links
+     on nodes.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  typedef link-id {
+    type inet:uri;
+    description
+      "An identifier for a link in a topology.  The precise
+       structure of the link-id will be up to the implementation.
+       The identifier SHOULD be chosen such that the same link in a
+       real network topology will always be identified through the
+       same identifier, even if the data model is instantiated in
+       separate datastores.  An implementation MAY choose to capture
+       semantics in the identifier -- for example, to indicate the
+       type of link and/or the type of topology of which the link is
+       a part.";
+  }
+
+  typedef tp-id {
+    type inet:uri;
+    description
+      "An identifier for termination points on a node.  The precise
+       structure of the tp-id will be up to the implementation.
+       The identifier SHOULD be chosen such that the same termination
+       point in a real network topology will always be identified
+       through the same identifier, even if the data model is
+       instantiated in separate datastores.  An implementation MAY
+       choose to capture semantics in the identifier -- for example,
+       to indicate the type of termination point and/or the type of
+       node that contains the termination point.";
+  }
+
+  grouping link-ref {
+    description
+      "This grouping can be used to reference a link in a specific
+       network.  Although it is not used in this module, it is
+       defined here for the convenience of augmenting modules.";
+    leaf link-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nt:link/nt:link-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a link instance.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw:network-ref;
+  }
+
+  grouping tp-ref {
+    description
+      "This grouping can be used to reference a termination point
+       in a specific node.  Although it is not used in this module,
+       it is defined here for the convenience of augmenting
+       modules.";
+    leaf tp-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nw:node[nw:node-id=current()/../"+
+          "node-ref]/nt:termination-point/nt:tp-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a termination point.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw:node-ref;
+  }
+
+  augment "/nw:networks/nw:network" {
+    description
+      "Add links to the network data model.";
+    list link {
+      key "link-id";
+      description
+        "A network link connects a local (source) node and
+         a remote (destination) node via a set of the respective
+         node's termination points.  It is possible to have several
+         links between the same source and destination nodes.
+         Likewise, a link could potentially be re-homed between
+         termination points.  Therefore, in order to ensure that we
+         would always know to distinguish between links, every link
+         is identified by a dedicated link identifier.  Note that a
+         link models a point-to-point link, not a multipoint link.";
+      leaf link-id {
+        type link-id;
+        description
+          "The identifier of a link in the topology.
+           A link is specific to a topology to which it belongs.";
+      }
+      container source {
+        description
+          "This container holds the logical source of a particular
+           link.";
+        leaf source-node {
+          type leafref {
+            path "../../../nw:node/nw:node-id";
+            require-instance false;
+          }
+          description
+            "Source node identifier.  Must be in the same topology.";
+        }
+        leaf source-tp {
+          type leafref {
+            path "../../../nw:node[nw:node-id=current()/../"+
+              "source-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the source node
+             and terminates the link.";
+        }
+      }
+
+      container destination {
+        description
+          "This container holds the logical destination of a
+           particular link.";
+        leaf dest-node {
+          type leafref {
+            path "../../../nw:node/nw:node-id";
+          require-instance false;
+          }
+          description
+            "Destination node identifier.  Must be in the same
+             network.";
+        }
+        leaf dest-tp {
+          type leafref {
+            path "../../../nw:node[nw:node-id=current()/../"+
+              "dest-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the
+             destination node and terminates the link.";
+        }
+      }
+      list supporting-link {
+        key "network-ref link-ref";
+        description
+          "Identifies the link or links on which this link depends.";
+        leaf network-ref {
+          type leafref {
+            path "../../../nw:supporting-network/nw:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which underlay topology
+             the supporting link is present.";
+        }
+
+        leaf link-ref {
+          type leafref {
+            path "/nw:networks/nw:network[nw:network-id=current()/"+
+              "../network-ref]/link/link-id";
+            require-instance false;
+          }
+          description
+            "This leaf identifies a link that is a part
+             of this link's underlay.  Reference loops in which
+             a link identifies itself as its underlay, either
+             directly or transitively, are not allowed.";
+        }
+      }
+    }
+  }
+  augment "/nw:networks/nw:network/nw:node" {
+    description
+      "Augments termination points that terminate links.
+       Termination points can ultimately be mapped to interfaces.";
+    list termination-point {
+      key "tp-id";
+      description
+        "A termination point can terminate a link.
+         Depending on the type of topology, a termination point
+         could, for example, refer to a port or an interface.";
+      leaf tp-id {
+        type tp-id;
+        description
+          "Termination point identifier.";
+      }
+      list supporting-termination-point {
+        key "network-ref node-ref tp-ref";
+        description
+          "This list identifies any termination points on which a
+           given termination point depends or onto which it maps.
+           Those termination points will themselves be contained
+           in a supporting node.  This dependency information can be
+           inferred from the dependencies between links.  Therefore,
+           this item is not separately configurable.  Hence, no
+           corresponding constraint needs to be articulated.
+           The corresponding information is simply provided by the
+           implementing system.";
+
+        leaf network-ref {
+          type leafref {
+            path "../../../nw:supporting-node/nw:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which topology the
+             supporting termination point is present.";
+        }
+        leaf node-ref {
+          type leafref {
+            path "../../../nw:supporting-node/nw:node-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which node the supporting
+             termination point is present.";
+        }
+        leaf tp-ref {
+          type leafref {
+            path "/nw:networks/nw:network[nw:network-id=current()/"+
+              "../network-ref]/nw:node[nw:node-id=current()/../"+
+              "node-ref]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "Reference to the underlay node (the underlay node must
+             be in a different topology).";
+        }
+      }
+    }
+  }
+}

--- a/yang/ietf-network@2018-02-26.yang
+++ b/yang/ietf-network@2018-02-26.yang
@@ -1,0 +1,192 @@
+module ietf-network {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network";
+  prefix nw;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+  description
+    "This module defines a common base data model for a collection
+     of nodes in a network.  Node definitions are further used
+     in network topologies and inventories.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  typedef node-id {
+    type inet:uri;
+    description
+      "Identifier for a node.  The precise structure of the node-id
+       will be up to the implementation.  For example, some
+       implementations MAY pick a URI that includes the network-id
+       as part of the path.  The identifier SHOULD be chosen
+       such that the same node in a real network topology will
+       always be identified through the same identifier, even if
+       the data model is instantiated in separate datastores.  An
+       implementation MAY choose to capture semantics in the
+       identifier -- for example, to indicate the type of node.";
+  }
+
+  typedef network-id {
+    type inet:uri;
+    description
+      "Identifier for a network.  The precise structure of the
+       network-id will be up to the implementation.  The identifier
+       SHOULD be chosen such that the same network will always be
+       identified through the same identifier, even if the data model
+       is instantiated in separate datastores.  An implementation MAY
+       choose to capture semantics in the identifier -- for example,
+       to indicate the type of network.";
+  }
+
+  grouping network-ref {
+    description
+      "Contains the information necessary to reference a network --
+       for example, an underlay network.";
+    leaf network-ref {
+      type leafref {
+        path "/nw:networks/nw:network/nw:network-id";
+      require-instance false;
+      }
+      description
+        "Used to reference a network -- for example, an underlay
+         network.";
+    }
+  }
+
+  grouping node-ref {
+    description
+      "Contains the information necessary to reference a node.";
+    leaf node-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nw:node/nw:node-id";
+        require-instance false;
+      }
+      description
+        "Used to reference a node.
+         Nodes are identified relative to the network that
+         contains them.";
+    }
+    uses network-ref;
+  }
+
+  container networks {
+    description
+      "Serves as a top-level container for a list of networks.";
+    list network {
+      key "network-id";
+      description
+        "Describes a network.
+         A network typically contains an inventory of nodes,
+         topological information (augmented through the
+         network-topology data model), and layering information.";
+      leaf network-id {
+        type network-id;
+        description
+          "Identifies a network.";
+      }
+      container network-types {
+        description
+          "Serves as an augmentation target.
+           The network type is indicated through corresponding
+           presence containers augmented into this container.";
+      }
+      list supporting-network {
+        key "network-ref";
+        description
+          "An underlay network, used to represent layered network
+           topologies.";
+        leaf network-ref {
+          type leafref {
+            path "/nw:networks/nw:network/nw:network-id";
+          require-instance false;
+          }
+          description
+            "References the underlay network.";
+        }
+      }
+
+      list node {
+        key "node-id";
+        description
+          "The inventory of nodes of this network.";
+        leaf node-id {
+          type node-id;
+          description
+            "Uniquely identifies a node within the containing
+             network.";
+        }
+        list supporting-node {
+          key "network-ref node-ref";
+          description
+            "Represents another node that is in an underlay network
+             and that supports this node.  Used to represent layering
+             structure.";
+          leaf network-ref {
+            type leafref {
+              path "../../../nw:supporting-network/nw:network-ref";
+            require-instance false;
+            }
+            description
+              "References the underlay network of which the
+               underlay node is a part.";
+          }
+          leaf node-ref {
+            type leafref {
+              path "/nw:networks/nw:network/nw:node/nw:node-id";
+            require-instance false;
+            }
+            description
+              "References the underlay node itself.";
+          }
+        }
+      }
+    }
+  }
+}

--- a/yang/ietf-yang-types@2013-07-15.yang
+++ b/yang/ietf-yang-types@2013-07-15.yang
@@ -1,0 +1,474 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/yang/tip-photonic-equipment.yang
+++ b/yang/tip-photonic-equipment.yang
@@ -1,0 +1,415 @@
+module tip-photonic-equipment {
+  yang-version 1.1;
+  namespace "https://oopt.telecominfraproject.com/yang/equipment";
+  prefix "tip-pe";
+
+  organization "Telecom Infrastructure Project";
+  contact "https://github.com/Telecominfraproject/oopt-gnpy";
+  description "Catalog of photonic equipment for simulating signal propagation via the OOPT-PSE GNPy tool";
+
+  revision 2019-06-20 {
+    description "Initial release";
+    reference "Internal documentation";
+  }
+
+  typedef db-ratio {
+    type decimal64 {
+      fraction-digits 2;
+    }
+    units "dB";
+    description "Decibels";
+  }
+
+  typedef noise-figure {
+    type db-ratio {
+      range 3.0..99.9;
+    }
+    description "Noise Figure of an amplifier";
+  }
+
+  typedef gain {
+    type db-ratio {
+      range 0..99.9;
+    }
+    description "Gain of an amplifier";
+  }
+
+  typedef power {
+    type decimal64 {
+      fraction-digits 2;
+      range -99.9..30.0;
+    }
+    units "dBm";
+    description "Optical power in dBm";
+  }
+
+  typedef frequency {
+    type decimal64 {
+      fraction-digits 6;
+      range 180..200;
+    }
+    units "THz";
+    description "Optical frequency in THz";
+  }
+
+  typedef polynomial-coefficient {
+    type decimal64 {
+      fraction-digits 6;
+    }
+    description "One coefficient within a polynomial";
+  }
+
+  grouping third-order-polynomial-coefficients {
+    description "Coefficients for a polynomial of a third order: f(x) = a*x³ + b*x² + c*x + d";
+    leaf a {
+      type polynomial-coefficient;
+      mandatory true;
+      description "Cubic (x³) coefficient";
+    }
+    leaf b {
+      type polynomial-coefficient;
+      mandatory true;
+      description "Quadratic (x²) coefficient";
+    }
+    leaf c {
+      type polynomial-coefficient;
+      mandatory true;
+      description "Linear (x) coefficient";
+    }
+    leaf d {
+      type polynomial-coefficient;
+      mandatory true;
+      description "Offset (+) coefficient";
+    }
+  }
+
+  grouping amp-spectrum-profile {
+    description "Changes in amplifier's operation as a function of frequency";
+
+    leaf-list gain-ripple {
+      type db-ratio;
+      ordered-by user;
+      // TODO: what exactly is this?
+      description "Amplifier gain ripple excursion comb list in dB across the frequency range.
+
+      Values are assumed to cover the whole frequency range of the amplifier (frequency-min to frequency-max)
+      uniformly and with a linear interpolation.";
+
+      default 0.0;
+    }
+
+    leaf-list nf-ripple {
+      type db-ratio;
+      ordered-by user;
+      description "Amplifier NF ripple excursion comb list in dB across the frequency range
+
+      Values are assumed to cover the whole frequency range of the amplifier (frequency-min to frequency-max)
+      uniformly and with a linear interpolation.";
+
+      default 0.0;
+    }
+
+    leaf-list dynamic-gain-tilt {
+      type db-ratio;
+      ordered-by user;
+      description "Dynamic Gain Tilt (DGT) refers to a relative change of gain
+      at a given frequency when compared to a reference frequency.
+
+      This parameter should be an array of gain corrections (in dB) applied on top of the desired gain.  The first value
+      refers to the lowest frequency, the last value refers to the highest supported frequency of the amplifier.
+
+      Intro about the model: https://telecominfraproject.workplace.com/groups/OOPT.PSE/permalink/957144244450445/
+      Relevant paper: https://www.osapublishing.org/jlt/abstract.cfm?uri=JLT-18-3-343";
+
+      default 0.0;
+    }
+  }
+
+  grouping amp-common {
+    description "Common parameters for all amplifier simulation implementations";
+
+    leaf gain-min {
+      type gain;
+      mandatory true;
+      description "Minimal possible gain of the amplifier";
+    }
+
+    leaf gain-flatmax {
+      type power;
+      mandatory true;
+      description "Operation point with maximal gain flatness";
+    }
+
+    leaf gain-max-extended {
+      type power;
+      mandatory true;
+      description "Maximal possible gain achievable by the amplifier. This might require enabling the extended gain range.";
+    }
+
+    leaf max-power-out {
+      type power;
+      mandatory true;
+      description "Maximal output power at the amplifier's output port";
+    }
+
+    uses amp-spectrum-profile;
+  }
+
+
+
+
+  list amplifier {
+    key "type";
+    description "Available amplifier (EDFA) models";
+
+    leaf type {
+      type string;
+      description "Brief identification of the amplifier model. This is used for cross-referencing from topology data.";
+    }
+
+    choice simulation {
+      mandatory true;
+      description "What simulation algorithm to use for this amplifier model";
+
+      case polynomial-NF {
+        container polynomial-NF {
+          description "Whitebox model with detailed information about gain ripple, NF ripple and dynamic gain tilt";
+
+          uses amp-common;
+
+          container nf-polynomial-coefficients {
+            description "Polynomial coefficients for NF calculation:
+
+            f(x) = a*x³ + b*x² + c*x + d
+
+            NF = f(gain_max - gain)";
+            uses third-order-polynomial-coefficients;
+          }
+        }
+      }
+
+      case polynomial-OSNR {
+        container polynomial-OSNR {
+          description "EDFA model based on the OpenROADM specification for an ILA";
+
+          uses amp-common;
+
+          container osnr-polynomial-coefficients {
+            description "OpenROADM describes amplifier performance in terms of an incremental OSNR as a function of input power:
+
+            Incremental OSNR = a*Pin³ + b*Pin² + c*Pin + d
+            ";
+            uses third-order-polynomial-coefficients;
+          }
+        }
+      }
+
+      case min-max-NF {
+        container min-max-NF {
+          description "Operator-focused model.
+
+          Performance is defined by minimal and maximal NF. These are especially suited to model a dual-coil
+          EDFA with a VOA in between.";
+
+          uses amp-common;
+
+          leaf nf-min {
+            type noise-figure;
+            mandatory true;
+            description "Minimal Noise Figure (operating at the maximal gain)";
+          }
+
+          leaf nf-max {
+            type noise-figure;
+            mandatory true;
+            description "Maximal Noise Figure (operating at the minimal gain)";
+          }
+        }
+      }
+
+      case raman {
+        container raman {
+          description "Raman amplifier -- a pump for the attached fiber";
+
+          leaf gain {
+            type gain;
+            mandatory true;
+            description "The (only) supported gain of this Raman amplifier. There is no gain range in this naive implementation.";
+          }
+
+          leaf nf {
+            type noise-figure;
+            mandatory true;
+            description "Effective noise figure of the amplifier.";
+          }
+        }
+      }
+
+      case dual-stage {
+        container dual-stage {
+          presence true;
+          description "Dual-stage amplifier uses two distinct amplifiers internally.
+          The first amplifier will be always operated at its maximal gain (and therefore minimal NF).";
+
+          leaf preamp {
+            type leafref {
+              path "/tip-pe:amplifier/type";
+            }
+            must "count(deref(.)/../dual-stage) = 0" {
+              error-message "First (preamp) stage of a dual-stage amplifier must be a single-stage EDFA";
+            }
+            mandatory true;
+            description "Amplifier type used as a preamplifier, i.e., the first stage";
+          }
+
+          leaf booster {
+            type leafref {
+              path "/tip-pe:amplifier/type";
+            }
+            must "count(deref(.)/../dual-stage) = 0" {
+              error-message "Second (booster) stage of a dual-stage amplifier must be a single-stage EDFA";
+            }
+            must "count(deref(.)/../raman) = 0" {
+              error-message "Second (booster) stage of a dual-stage amplifier cannot be a Raman amplifier (co-propagation is not supported)";
+            }
+            mandatory true;
+            description "Amplifier type used as a booster, i.e., the second stage";
+          }
+
+          leaf gain-min {
+            type power;
+            mandatory true;
+            description "Minimal supported gain of the whole combination. This value is
+            used in the auto-design mode for determining when to use a dual-stage amplifier.";
+          }
+        }
+      }
+    }
+
+    leaf frequency-min {
+      type frequency;
+      default 191.35;
+      description "Minimal frequency supported by this amplifier";
+    }
+
+    leaf frequency-max {
+      type frequency;
+      default 196.1;
+      description "Maximal frequency supported by this amplifier";
+    }
+
+    leaf has-output-voa {
+      type boolean;
+      default false;
+      description "If true, output VOA is present.
+
+      This affects operation of autodesign and will be used to push amplifier gain to its maximum, within EOL power margins.";
+    }
+  }
+
+
+  list fiber {
+    key "type";
+    description "Available fiber types";
+
+    leaf type {
+      type string;
+      description "Unique identification of the fiber type. This is used for cross-referencing from topology data.";
+    }
+
+    leaf dispersion {
+      type decimal64 {
+        fraction-digits 10; // FIXME
+      }
+      units "s*m⁻¹*m⁻¹";
+      mandatory true;
+      description "Chromatic dispersion";
+    }
+
+    leaf gamma {
+      type decimal64 {
+        fraction-digits 10; // FIXME
+      }
+      units "2pi.n2/(lambda*Aeff) (w-2.m-1)"; // FIXME: unicode? :)
+      mandatory true;
+      description ""; // FIXME
+    }
+  }
+
+
+  list transceiver {
+    key "type";
+    description "Available transceivers";
+
+    leaf type {
+      type string;
+      description "Unique identification of the transponder type. This is used for cross-referencing from topology data.";
+    }
+
+    leaf frequency-min {
+      type frequency;
+      default 191.35;
+      description "Minimal frequency supported by this transceiver model";
+    }
+
+    leaf frequency-max {
+      type frequency;
+      default 196.1;
+      description "Maximal frequency supported by this transceiver model";
+    }
+
+    list mode {
+      key "name";
+      description "Operating mode of a transceiver";
+
+      leaf name {
+        type string;
+        description "Name of this operating mode";
+      }
+
+      leaf baud-rate {
+        type uint64;
+        units "Baud";
+        mandatory true;
+        description "Symbol baud rate";
+      }
+
+      leaf required-osnr {
+        type db-ratio;
+        mandatory true;
+        description "Minimal required OSNR at the Rx port";
+      }
+
+      leaf tx-osnr {
+        type db-ratio;
+        mandatory true;
+        description "Worst-case guaranteed initial OSNR at the Tx port";
+      }
+
+      leaf grid-spacing {
+        type frequency;
+        mandatory true;
+        description "Minimal grid spacing, i.e., an effective channel spectral bandwidth";
+      }
+
+      leaf tx-roll-off {
+        type decimal64 {
+          fraction-digits 4;
+          range 0..1;
+        }
+        description "Roll-off parameter (β) of the TX pulse shaping filter. This assumes a raised-cosine filter.";
+      }
+
+      leaf cost {
+        type uint32;
+        units "Arbitrary units";
+        default 1;
+        description "Cost of selecting this mode when determining path feasibility";
+      }
+
+    }
+  }
+
+
+  // FIXME: ROADM
+}

--- a/yang/tip-photonic-equipment.yang
+++ b/yang/tip-photonic-equipment.yang
@@ -411,5 +411,20 @@ module tip-photonic-equipment {
   }
 
 
+  list roadm {
+    key "type";
+    description "Available transceivers";
+
+    leaf type {
+      type string;
+      description "Unique identification of the ROADM model. This is used for cross-referencing from topology data.";
+    }
+
+    leaf per-channel-target-power {
+      type power;
+    }
+  }
+
+
   // FIXME: ROADM
 }

--- a/yang/tip-photonic-topology.yang
+++ b/yang/tip-photonic-topology.yang
@@ -18,6 +18,11 @@ module tip-photonic-topology {
     revision-date 2018-02-26;
   }
 
+  import ietf-geo-location {
+    prefix geo;
+    revision-date 2019-02-17;
+  }
+
   organization "Telecom Infrastructure Project";
   contact "https://github.com/Telecominfraproject/oopt-gnpy";
   description "Network topology for simulating signal propagation via the OOPT-PSE GNPy tool";
@@ -103,30 +108,6 @@ module tip-photonic-topology {
     when "../nw:network-types/tip-pt:photonic-topology";
     description "Optical elements within a network";
 
-    // TODO: a generic model for this?
-    container location {
-      description "Real-world physical position of this thing";
-
-      leaf name {
-        type string;
-        description "Human-friendly location";
-      }
-
-      leaf latitude {
-        type geo-coordinate {
-          range -90..90;
-        }
-        description "Latitude within a globe";
-      }
-
-      leaf longitude {
-        type geo-coordinate {
-          range -180..180;
-        }
-        description "Longitude within a globe";
-      }
-    }
-
     choice element {
       mandatory true;
       description "A physical instance of something";
@@ -182,6 +163,12 @@ module tip-photonic-topology {
         }
       }
 
+    }
+
+    uses geo:geo-location {
+      refine geo-location/location {
+        mandatory false;
+      }
     }
   }
 }

--- a/yang/tip-photonic-topology.yang
+++ b/yang/tip-photonic-topology.yang
@@ -1,0 +1,187 @@
+module tip-photonic-topology {
+  yang-version 1.1;
+  namespace "https://oopt.telecominfraproject.com/yang/topology";
+  prefix "tip-pt";
+
+  import tip-photonic-equipment {
+    prefix tip-pe;
+    revision-date 2019-06-20;
+  }
+
+  import ietf-network {
+    prefix nw;
+    revision-date 2018-02-26;
+  }
+
+  import ietf-network-topology {
+    prefix nt;
+    revision-date 2018-02-26;
+  }
+
+  organization "Telecom Infrastructure Project";
+  contact "https://github.com/Telecominfraproject/oopt-gnpy";
+  description "Network topology for simulating signal propagation via the OOPT-PSE GNPy tool";
+
+  revision 2019-07-02 {
+    description "Initial release";
+    reference "Internal documentation";
+  }
+
+  typedef geo-coordinate {
+    type decimal64 {
+      fraction-digits 6;
+    }
+    description "Intermediate type for a geographic coordinate";
+  }
+
+  augment "/nw:networks/nw:network/nw:network-types" {
+    description "Telecom Infra Project Open Optical Packet Transport Photonic Simulation Environment";
+    container photonic-topology {
+      presence "indicates topology describing optical elements";
+      description "The presence of this container indicates a topology with optical elements";
+    }
+  }
+
+  augment "/nw:networks/nw:network/nt:link" {
+    when "../nw:network-types/tip-pt:photonic-topology";
+    description "Connections of optical components";
+
+    container fiber {
+      description "Fiber connection";
+
+      leaf type {
+        type leafref {
+          path "/tip-pe:fiber/tip-pe:type";
+        }
+        mandatory true;
+        description "Fiber type cross-reference";
+      }
+
+      leaf length {
+        type decimal64 {
+          fraction-digits 3;
+        }
+        mandatory true;
+        units "km";
+        description "Length of the fiber segment";
+      }
+
+      leaf loss-per-km {
+        type decimal64 {
+          fraction-digits 6;
+          range "0..10";
+        }
+        units "dB/km";
+        description "Attenuation per kilometer of fiber";
+        default 0.2;
+      }
+
+      leaf attenuation-in {
+        type tip-pe:db-ratio {
+          range "0..100";
+        }
+        default 0;
+      }
+
+      leaf conn-att-in {
+        type tip-pe:db-ratio {
+          range "0..100";
+        }
+        default 0;
+      }
+
+      leaf conn-att-out {
+        type tip-pe:db-ratio {
+          range "0..100";
+        }
+        default 0;
+      }
+    }
+  }
+
+  augment "/nw:networks/nw:network/nw:node" {
+    when "../nw:network-types/tip-pt:photonic-topology";
+    description "Optical elements within a network";
+
+    // TODO: a generic model for this?
+    container location {
+      description "Real-world physical position of this thing";
+
+      leaf name {
+        type string;
+        description "Human-friendly location";
+      }
+
+      leaf latitude {
+        type geo-coordinate {
+          range -90..90;
+        }
+        description "Latitude within a globe";
+      }
+
+      leaf longitude {
+        type geo-coordinate {
+          range -180..180;
+        }
+        description "Longitude within a globe";
+      }
+    }
+
+    choice element {
+      mandatory true;
+      description "A physical instance of something";
+
+      case amplifier {
+        container amplifier {
+          description "Amplifier";
+
+          leaf model {
+            type leafref {
+              path "/tip-pe:amplifier/tip-pe:type";
+            }
+            mandatory true;
+            description "Amplifier model cross-reference";
+          }
+
+          leaf gain-target {
+            type tip-pe:gain;
+            description "Desired gain of the amplifier";
+          }
+
+          leaf tilt-target {
+            type tip-pe:db-ratio;
+            // FIXME: make this available only when the amplifier model supports tilting
+            description "Desired gain of the amplifier";
+          }
+        }
+      }
+
+      case concentrated-loss {
+        container concentrated-loss {
+          description "Attenuator, or a straight splice";
+
+          leaf attenuation {
+            type tip-pe:db-ratio;
+            default 0;
+            description "Attenuator loss";
+          }
+        }
+      }
+
+      case transceiver {
+        container transceiver {
+          description "Transceiver";
+
+          leaf model {
+            type leafref {
+              path "/tip-pe:transceiver/tip-pe:type";
+            }
+            mandatory true;
+            description "Transceiver model, a cross-reference to the equipment library";
+          }
+        }
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
Right now, the documentation and code disagree on which values are mandatory, what exactly they mean, etc. Let's try to use a set of YANG models for verification.

## FIXME: What is missing

- [ ] ROADMs
- [ ] EDFA parameters
  - [ ] TODO: implement DGT (et al) indirection
  - [x] check that this set of EDFA parameters makes sense for each possible simulation parameter set
  - [x] rework for #227
  - [x] EDFA maximal gain -- this one doesn't appear to be used by the code anywhere!, which confuses me
  - [x] Raman support (preliminary, on-par with what we already have now in `devel`)
- [x] Fibers
  - [ ] Fiber.dispersion and Fiber.gamma range validation. Also, how do we describe Fiber type's gamma?
  - [x] Fiber operational data
- [x] Transponders
  - [x] Transceiver's tx roll-off; how exactly is this defined? I only understand it "intuitively".
  - [ ] minimal required OSNR (#298)
- [x] topology
  - [x] use [`ietf-network-topology`](https://tools.ietf.org/html/rfc8345#section-4.2) for topology (this is *not* about the [impariment-aware CCAMP work](https://github.com/younglee-ietf/ietf-optical-impairment-yang))
  - [ ] More XPath bits for topology validation -- connecting just those elements which make sense together
- [ ] replace `SpectralInfo`
  - [ ] default transponder for `transmission_main_example`
  - [ ] unclear how to reconcile the `f_min`/`f_max` of the SI and TX
  - [ ] default spectrum allocation (autodesign assumes full allocation -> cannot use transponders)
- [ ] CI coverage:
  - [ ] YANG validation & linting
  - [ ] positive and negative JSON samples for constraint testing
    - "ignoring the YANG-specificity":
      - use [this `jsonschema` plugin to `pyang`](https://github.com/cmoberg/pyang-json-schema-plugin/blob/master/jsonschema/jsonschema.py) or [this `jsonschema` plugin for `pyang`](https://github.com/OpenNetworkingFoundation/EagleUmlCommon/blob/ToolChain/YangJsonTools/json_schema.py)
      - feed their results into [jsonschema](https://python-jsonschema.readthedocs.io/en/stable/) for actual JSON validation
    - **or** just use `yanglint` proper, because it works (but might be a bit painful to package for CI and users),
    - [ ] **or** use [yangson](https://github.com/CZ-NIC/yangson), a native Python library
      - [ ] prepare the JSON data in the `ietf-yang-library` format
- [ ] input validation
  - this one should be in Python, not via `yanglint` for dependency reasons
- [ ] conversion scripts
- [ ] use this as an input format

## Equipment Library

The first step in adding YANG description for gnpy's input is the equipment library (`tip-photonic-equipment`). It contains data about all defined EDFA and Fiber types. This is supposed to be functionally equivalent to the `equpt_config.json`. The JSON structure has changed because I (much) value YANG readability over being directly compatible with our previous format (there will be a conversion script anyway).

The core idea of this model is to describe capabilities of the simulation engine as it exists, which means that the individual choice/case statements mirror our different "simulation input parameters". The user is not expected to do any augmentations -- just describe the amplifiers, fiber, etc, with data.

The pre-YANG code actually split stuff from `equpt_config.json` into additional JSON files for "fancy bits", such as the DGT LUT. That's something that, IMHO, does not make sense when we're willing to ship with machine-validation of the complete input set. So instead of deferring to another JSON file for the NF-/gain-ripple/DGT, let's move everything in-line into the input data. This has one obvious downside in making the amplifier data a bit too verbose. There were several options:

- Ignore the human-friendliness and push everything into the amplifier description. This is nice and self-contained, but the data are going to be very, very long, and the majority of the WG was worried that it would make human editing too difficult.

- Move everything to a side-loaded JSON file. This option separates out some numerical parameters from the equipment library, and therefore splits the configuration into two places. One of these places would be exempt from the YANG validation, and loaded via unspecified means.  That's a no-go.

- Put stuff into a YANG model, but use one level of indirection between the amplifier description and the numerical data.

As a compromise, we've chosen the last option.

In the real world, some "common fiber types" are well-defined by ITU, such as the SSMF. Esther tried to model this via a set of identities and YANG `identityref`s. I think that there's no disadvantage in shipping these data as a default content of the YANG-formatted datastore, similarly to how the equipment library used to be structured prior to this patch. Once again, I'm following the pattern where the user can change any *data* without augmenting the YANG model. The only reason for editing/augmenting the (equipment) YANG model should be changes in our simulation *engine*, such as when adding different input parameters for NF calculations, or adding Raman amplification, etc.

The amplifier model has been reworked a bit (only in the YANG model for now, though). I've reduced the number of available "simulation parameters" to a reasonable minimum as suggested by Jean-Luc (cf. issue #227):

- a polynomial NF model
- a polynomial OSNR model ("OpenROADM")
- a simplified model for operators with NF_min and NF_max
- a dual-stage amplifier using any of the above

## Topology Model

The topology model (`tip-photonic-topology`) uses `leafref`s for "instantiating" actual nodes from models defined in the equipment library. The topology is unidirectional.

At first, I used an ad-hoc, custom topology for simplicity. This was changed in response to Jonas' comment; there's clearly no need to reinvent this particular wheel. Now the model builds on top of RFC8345.
    
Both [`ietf-network-topology`](https://tools.ietf.org/html/rfc8345#section-4.2) and the associated `ietf-network` are needed.  The augmentations make it a bit harder to see the YANG rendering of the resulting modules, but that's just how the IETF model was designed.  There's nothing to fix on our side.

Unlike the current JSON, Fibers are not nodes anymore. They are implemented as `nt:link` augmentations.

## Sample Data

To see how the (total, complete) input data to GNPy might look like, I'm including [a simple JSON file]( https://github.com/Telecominfraproject/oopt-gnpy/pull/266/files?file-filters%5B%5D=.json) which defines some amplifiers, fiber, transponders, etc., and uses them to build a very simple path. I think that there's plenty of stuff which is missing, but it shows something which passes the YANG validation.

## YANG trees

### Equipment Inventory
```
module: tip-photonic-equipment
  +--rw amplifier* [type]
  |  +--rw type              string
  |  +--rw (simulation)
  |  |  +--:(polynomial-NF)
  |  |  |  +--rw polynomial-NF
  |  |  |     +--rw gain-min                      gain
  |  |  |     +--rw gain-flatmax                  power
  |  |  |     +--rw gain-max-extended             power
  |  |  |     +--rw max-power-out                 power
  |  |  |     +--rw gain-ripple*                  db-ratio
  |  |  |     +--rw nf-ripple*                    db-ratio
  |  |  |     +--rw dynamic-gain-tilt*            db-ratio
  |  |  |     +--rw nf-polynomial-coefficients
  |  |  |        +--rw a    polynomial-coefficient
  |  |  |        +--rw b    polynomial-coefficient
  |  |  |        +--rw c    polynomial-coefficient
  |  |  |        +--rw d    polynomial-coefficient
  |  |  +--:(polynomial-OSNR)
  |  |  |  +--rw polynomial-OSNR
  |  |  |     +--rw gain-min                        gain
  |  |  |     +--rw gain-flatmax                    power
  |  |  |     +--rw gain-max-extended               power
  |  |  |     +--rw max-power-out                   power
  |  |  |     +--rw gain-ripple*                    db-ratio
  |  |  |     +--rw nf-ripple*                      db-ratio
  |  |  |     +--rw dynamic-gain-tilt*              db-ratio
  |  |  |     +--rw osnr-polynomial-coefficients
  |  |  |        +--rw a    polynomial-coefficient
  |  |  |        +--rw b    polynomial-coefficient
  |  |  |        +--rw c    polynomial-coefficient
  |  |  |        +--rw d    polynomial-coefficient
  |  |  +--:(min-max-NF)
  |  |  |  +--rw min-max-NF
  |  |  |     +--rw gain-min             gain
  |  |  |     +--rw gain-flatmax         power
  |  |  |     +--rw gain-max-extended    power
  |  |  |     +--rw max-power-out        power
  |  |  |     +--rw gain-ripple*         db-ratio
  |  |  |     +--rw nf-ripple*           db-ratio
  |  |  |     +--rw dynamic-gain-tilt*   db-ratio
  |  |  |     +--rw nf-min               noise-figure
  |  |  |     +--rw nf-max               noise-figure
  |  |  +--:(raman)
  |  |  |  +--rw raman
  |  |  |     +--rw gain    gain
  |  |  |     +--rw nf      noise-figure
  |  |  +--:(dual-stage)
  |  |     +--rw dual-stage!
  |  |        +--rw preamp      -> /tip-photonic-equipment:amplifier/type
  |  |        +--rw booster     -> /tip-photonic-equipment:amplifier/type
  |  |        +--rw gain-min    power
  |  +--rw frequency-min?    frequency <191.35>
  |  +--rw frequency-max?    frequency <196.1>
  |  +--rw has-output-voa?   boolean <false>
  +--rw fiber* [type]
  |  +--rw type          string
  |  +--rw dispersion    decimal64
  |  +--rw gamma         decimal64
  +--rw transceiver* [type]
     +--rw type             string
     +--rw frequency-min?   frequency <191.35>
     +--rw frequency-max?   frequency <196.1>
     +--rw mode* [name]
        +--rw name             string
        +--rw baud-rate        uint64
        +--rw required-osnr    db-ratio
        +--rw tx-osnr          db-ratio
        +--rw grid-spacing     frequency
        +--rw tx-roll-off?     decimal64
        +--rw cost?            uint32 <1>
```
### Topology
```
module: tip-photonic-topology

  augment /ietf-network:networks/ietf-network:network/ietf-network:network-types:
    +--rw photonic-topology!
  augment /ietf-network:networks/ietf-network:network/ietf-network-topology:link:
    +--rw fiber
       +--rw type      -> /tip-photonic-equipment:fiber/tip-photonic-equipment:type
       +--rw length    decimal64
  augment /ietf-network:networks/ietf-network:network/ietf-network:node:
    +--rw (element)
    |  +--:(amplifier)
    |  |  +--rw amplifier
    |  |     +--rw model          -> /tip-photonic-equipment:amplifier/tip-photonic-equipment:type
    |  |     +--rw gain-target    tip-photonic-equipment:gain
    |  |     +--rw tilt-target    tip-photonic-equipment:db-ratio
    |  +--:(concentrated-loss)
    |  |  +--rw concentrated-loss
    |  |     +--rw attenuation?   tip-photonic-equipment:db-ratio <0.0>
    |  +--:(transceiver)
    |     +--rw transceiver
    |        +--rw model    -> /tip-photonic-equipment:transceiver/tip-photonic-equipment:type
    +--rw geo-location
    |  +--rw reference-frame
    |  |  +--rw alternate-system?    string {ietf-geo-location:alternate-systems}?
    |  |  +--rw astronomical-body?   string <earth>
    |  |  +--rw geodetic-system
    |  |     +--rw geodetic-datum?    string <wgs-84>
    |  |     +--rw coord-accuracy?    decimal64
    |  |     +--rw height-accuracy?   decimal64
    |  +--rw (location)?
    |  |  +--:(ellipsoid)
    |  |  |  +--rw latitude     ietf-geo-location:degrees
    |  |  |  +--rw longitude    ietf-geo-location:degrees
    |  |  |  +--rw height?      decimal64
    |  |  +--:(cartesian)
    |  |     +--rw x    decimal64
    |  |     +--rw y    decimal64
    |  |     +--rw z?   decimal64
    |  +--rw velocity
    |  |  +--rw v-north?   decimal64
    |  |  +--rw v-east?    decimal64
    |  |  +--rw v-up?      decimal64
    |  +--rw timestamp?         ietf-yang-types:date-and-time
```