### PR TITLE
Ila names in constraints

### DIFF
--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -353,13 +353,11 @@ def correct_xls_route_list(network_filename, network, pathreqlist):
                         else:
                             new_n = nodes_suggestion[0]
                         if new_n != n_id:
-                            # warns the user when the name is changed,
-                            # eg 'a' is a roadm and name is 'roadm a' or when there was
-                            # too much ambiguity, 'b' is a ila, its name can be
+                            # warns the user when the correct name is used only in verbose mode,
+                            # eg 'a' is a roadm and correct name is 'roadm a' or when there was
+                            # too much ambiguity, 'b' is an ila, its name can be
                             # Edfa0_fiber (a → b)-xx if next node is c or
                             # Edfa0_fiber (c → b)-xx if next node is a
-                            print(f'\x1b[1;33;40m'+f'invalid route node specified:' +\
-                                  f'\n\t\'{n_id}\', replaced with \'{new_n}\''+'\x1b[0m')
                             LOGGER.info(f'\x1b[1;33;40m'+f'invalid route node specified:' +\
                                   f'\n\t\'{n_id}\', replaced with \'{new_n}\''+'\x1b[0m')
                             pathreq.nodes_list[pathreq.nodes_list.index(n_id)] = new_n

--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -596,10 +596,17 @@ def main(args):
         LOGGER.critical(msg)
         exit()
     try:
-        rqs = correct_route_list(network, rqs)
+        if ARGS.network_filename.suffix.lower() == '.xls':
+            # only correct namings in route constraint if users entry is xls.
+            # else it is assumed that the constraints follow the json given name
+
+            rqs = correct_xls_route_list(ARGS.network_filename, network, rqs)
+        else:
+            rqs = correct_json_route_list(network, rqs)
     except ServiceError as this_e:
         print(f'{ansi_escapes.red}Service error:{ansi_escapes.reset} {this_e}')
         exit(1)
+
     # pths = compute_path(network, equipment, rqs)
     dsjn = disjunctions_from_json(data)
 

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -736,13 +736,12 @@ def compute_path_dsjctn(network, equipment, pathreqlist, disjunctions_list):
     # select the disjoint path combination
 
     candidates = {}
-    for d in disjunctions_list:
-        dlist = d.disjunctions_req.copy()
+    for dis in disjunctions_list:
+        dlist = dis.disjunctions_req.copy()
         # each line of dpath is one combination of path that satisfies disjunction
         dpath = []
         for i, pth in enumerate(simple_rqs[dlist[0]]):
             dpath.append([pth])
-            # allpaths[id(p)].d_id = d.disjunction_id
         # in each loop, dpath is updated with a path for rq that satisfies
         # disjunction with each path in dpath
         # for example, assume set of requests in the vector (disjunction_list) is  {rq1,rq2, rq3}
@@ -788,7 +787,7 @@ def compute_path_dsjctn(network, equipment, pathreqlist, disjunctions_list):
                             # print(f' coucou {elem1}: \t{temp}')
             dpath = temp
         # print(dpath)
-        candidates[d.disjunction_id] = dpath
+        candidates[dis.disjunction_id] = dpath
 
     # for i in disjunctions_list:
     #     print(f'\n{candidates[i.disjunction_id]}')

--- a/gnpy/core/service_sheet.py
+++ b/gnpy/core/service_sheet.py
@@ -104,21 +104,27 @@ class Request_element(Element):
         # cleaning the list of nodes to remove source and destination
         # (because the remaining of the program assumes that the nodes list are nodes 
         # on the path and should not include source and destination)
-        try :
-            self.nodes_list.remove(self.source)
-            msg = f'{self.source} removed from explicit path node-list'
-            logger.info(msg)
-        except ValueError:
-            msg = f'{self.source} already removed from explicit path node-list'
-            logger.info(msg)
+        # try :
+        #     self.nodes_list.remove(self.source)
+        #     msg = f'{self.source} removed from explicit path node-list'
+        #     logger.info(msg)
+        # except ValueError:
+        #     msg = f'{self.source} already removed from explicit path node-list'
+        #     logger.info(msg)
 
-        try :
-            self.nodes_list.remove(self.destination)
-            msg = f'{self.destination} removed from explicit path node-list'
-            logger.info(msg)
-        except ValueError:
-            msg = f'{self.destination} already removed from explicit path node-list'
-            logger.info(msg)
+        # with excel input, last and first node in the list must be a roadm
+        # TODO add a verification for consistency in service sheet + exception
+        # then no need to remove last node because destination that will be added next
+        # is the transciver node
+
+
+        # try :
+        #     self.nodes_list.remove(self.destination)
+        #     msg = f'{self.destination} removed from explicit path node-list'
+        #     logger.info(msg)
+        # except ValueError:
+        #     msg = f'{self.destination} already removed from explicit path node-list'
+        #     logger.info(msg)
 
         # the excel parser applies the same hop-type to all nodes in the route nodes_list.
         # user can change this per node in the generated json

--- a/tests/test_automaticmodefeature.py
+++ b/tests/test_automaticmodefeature.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pytest
 from gnpy.core.equipment import load_equipment, trx_mode_params, automatic_nch
 from gnpy.core.network import load_network, build_network
-from examples.path_requests_run import requests_from_json, correct_route_list, load_requests
+from examples.path_requests_run import requests_from_json, correct_json_route_list, load_requests
 from gnpy.core.request import compute_path_dsjctn, propagate, propagate_and_optimize_mode
 from gnpy.core.utils import db2lin, lin2db
 from gnpy.core.elements import Roadm
@@ -47,7 +47,7 @@ def test_automaticmodefeature(net,eqpt,serv,expected_mode):
     build_network(network, equipment, p_db, p_total_db)
 
     rqs = requests_from_json(data, equipment)
-    rqs = correct_route_list(network, rqs)
+    rqs = correct_json_route_list(network, rqs)
     dsjn = []
     pths = compute_path_dsjctn(network, equipment, rqs, dsjn)
     path_res_list = []

--- a/tests/test_disjunction.py
+++ b/tests/test_disjunction.py
@@ -14,9 +14,9 @@ from pathlib import Path
 import pytest
 from gnpy.core.equipment import load_equipment, trx_mode_params, automatic_nch
 from gnpy.core.network import load_network, build_network
-from examples.path_requests_run import (requests_from_json , correct_json_route_list ,
-                                        load_requests , disjunctions_from_json)
-from gnpy.core.request import compute_path_dsjctn, isdisjoint , find_reversed_path
+from examples.path_requests_run import (requests_from_json, correct_json_route_list,
+                                        load_requests, disjunctions_from_json)
+from gnpy.core.request import compute_path_dsjctn, isdisjoint, find_reversed_path
 from gnpy.core.utils import db2lin, lin2db
 from gnpy.core.elements import Roadm
 from gnpy.core.spectrum_assignment import build_oms_list

--- a/tests/test_disjunction.py
+++ b/tests/test_disjunction.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 from gnpy.core.equipment import load_equipment, trx_mode_params, automatic_nch
 from gnpy.core.network import load_network, build_network
-from examples.path_requests_run import (requests_from_json , correct_route_list ,
+from examples.path_requests_run import (requests_from_json , correct_json_route_list ,
                                         load_requests , disjunctions_from_json)
 from gnpy.core.request import compute_path_dsjctn, isdisjoint , find_reversed_path
 from gnpy.core.utils import db2lin, lin2db
@@ -44,7 +44,7 @@ def test_disjunction(net,eqpt,serv):
     build_oms_list(network, equipment)
 
     rqs = requests_from_json(data, equipment)
-    rqs = correct_route_list(network, rqs)
+    rqs = correct_json_route_list(network, rqs)
     dsjn = disjunctions_from_json(data)
     pths = compute_path_dsjctn(network, equipment, rqs, dsjn)
     print(dsjn)
@@ -84,7 +84,7 @@ def test_does_not_loop_back(net,eqpt,serv):
     build_oms_list(network, equipment)
 
     rqs = requests_from_json(data, equipment)
-    rqs = correct_route_list(network, rqs)
+    rqs = correct_json_route_list(network, rqs)
     dsjn = disjunctions_from_json(data)
     pths = compute_path_dsjctn(network, equipment, rqs, dsjn)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,7 +33,7 @@ from gnpy.core.request import (jsontocsv, requests_aggregation,
 from gnpy.core.spectrum_assignment import build_oms_list, pth_assign_spectrum
 from gnpy.core.exceptions import ServiceError
 from examples.path_requests_run import (requests_from_json, disjunctions_from_json,
-                                        correct_route_list, correct_disjn,
+                                        correct_xls_route_list, correct_disjn,
                                         compute_path_with_disjunction)
 
 TEST_DIR = Path(__file__).parent
@@ -293,7 +293,7 @@ def test_json_response_generation(xls_input, expected_response_file):
     build_network(network, equipment, p_db, p_total_db)
     oms_list = build_oms_list(network, equipment)
     rqs = requests_from_json(data, equipment)
-    rqs = correct_route_list(network, rqs)
+    rqs = correct_xls_route_list(xls_input, network, rqs)
     dsjn = disjunctions_from_json(data)
     dsjn = correct_disjn(dsjn)
     rqs, dsjn = requests_aggregation(rqs, dsjn)


### PR DESCRIPTION
    Enable ILA and FUSED type in routing constraints with xls input
    
    - builds correspondance dicts between input name from excel
      and names created with convert.py and autodesign in network.py
    - correct the corresp_name dicts according to the effective
      network autodesign. This supports the case of fiber splitting
      and of fused elements
    - include the case of parallel links with only one hop
    - interpret the node list constraint given by the user with the dict
    - filter the constraints that are not applicable
    
    ILA and FUSED constraints must be filled with the next node
    information in order to avoid confusion on the direction.
    for example
         eg   
'
 a----b-----c
 |       |       |
 i       j       k
 |       |       |
 e----f-----g
 '   
a constraint 'j' given for service i to k leads to 2 possible direction:
    i-a-b-j-f-g-k
    i-e-f-j-b-c-k
    the user must indicate the chosen direction. This ambiguity does not
    exist with network input in json format (names are unique).

This PR adresses #272     
TODO: 
complete readme files with info
use this to correct plot
