### PR TITLE
CI: tests: include examples in coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ install:
 script:
   - pytest --cov-report=xml --cov=gnpy
   - rstcheck --ignore-roles cite --ignore-directives automodule --recursive --ignore-messages '(Duplicate explicit target name.*)' .
-  - ./examples/transmission_main_example.py
-  - ./examples/path_requests_run.py
-  - ./examples/transmission_main_example.py examples/raman_edfa_example_network.json --sim examples/sim_params.json --show-channels
   - sphinx-build docs/ x-throwaway-location
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,24 @@
+import subprocess
+
+def test_transmission_main_example(capfd):
+    res = subprocess.run(['./examples/transmission_main_example.py'])
+    assert res.returncode == 0
+    captured = capfd.readouterr()
+    assert captured.err == ""
+    assert 'SNR total (signal bw, dB): 26.27' in captured.out
+
+def test_path_request_run(capfd):
+    res = subprocess.run(['./examples/path_requests_run.py'])
+    assert res.returncode == 0
+    captured = capfd.readouterr()
+    assert captured.err == ""
+
+def test_transmission_main_example_raman(capfd):
+    res = subprocess.run(['./examples/transmission_main_example.py',
+                          'examples/raman_edfa_example_network.json',
+                          '--sim', 'examples/sim_params.json',
+                          '--show-channels'])
+    assert res.returncode == 0
+    captured = capfd.readouterr()
+    assert captured.err == ""
+    assert 'SNR total (signal bw, dB): 26.48' in captured.out


### PR DESCRIPTION
This might be a wee bit controversial. On one hand, having "real", fine-grained tests and the associated coverage reports is very valuable in identifying code which is suspicious because there's nothing guarding that it still works.

On the other hand, the recent Raman work came with no test coverage.

I think that it's a reasonable compromise to introduce the existing examples into the autotest suite. That way we can see whether changes at least touch stuff that is "needed by the examples"...