### PR TITLE
Automatic building of Docker images

### DIFF
--- a/.docker-entry.sh
+++ b/.docker-entry.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cp -nr /oopt-gnpy/examples /shared
+exec "$@"

--- a/.docker-travis.sh
+++ b/.docker-travis.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME=telecominfraproject/oopt-gnpy
+IMAGE_TAG=$(git describe --tags)
+
+ALREADY_FOUND=0
+docker pull ${IMAGE_NAME}:${IMAGE_TAG} && ALREADY_FOUND=1
+
+if [[ $ALREADY_FOUND == 0 ]]; then
+  docker build . -t ${IMAGE_NAME}
+  docker tag ${IMAGE_NAME} ${IMAGE_NAME}:${IMAGE_TAG}
+
+  # shared directory setup: do not clobber the real data
+  mkdir trash
+  cd trash
+  docker run -it --rm --volume $(pwd):/shared ${IMAGE_NAME} ./transmission_main_example.py
+else
+  echo "Image ${IMAGE_NAME}:${IMAGE_TAG} already available, will just update the other tags"
+fi
+
+docker images
+
+do_docker_login() {
+  echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+}
+
+if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+  if [[ "${TRAVIS_BRANCH}" == "develop" || "${TRAVIS_BRANCH}" == "docker" ]]; then
+    echo "Publishing latest"
+    docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:latest
+    do_docker_login
+    if [[ $ALREADY_FOUND == 0 ]]; then
+      docker push ${IMAGE_NAME}:${IMAGE_TAG}
+    fi
+    docker push ${IMAGE_NAME}:latest
+  elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
+    echo "Publishing stable"
+    docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:stable
+    do_docker_login
+    if [[ $ALREADY_FOUND == 0 ]]; then
+      docker push ${IMAGE_NAME}:${IMAGE_TAG}
+    fi
+    docker push ${IMAGE_NAME}:stable
+  fi
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 dist: xenial
 sudo: false
 language: python
+services: docker
 python:
   - "3.6"
   - "3.7"
-# command to install dependencies
-install:
+install: skip
+script:
   - python setup.py install
   - pip install pytest-cov rstcheck
-script:
   - pytest --cov-report=xml --cov=gnpy
   - rstcheck --ignore-roles cite --ignore-directives automodule --recursive --ignore-messages '(Duplicate explicit target name.*)' .
   - ./examples/transmission_main_example.py
@@ -17,3 +17,10 @@ script:
   - sphinx-build docs/ x-throwaway-location
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+jobs:
+  include:
+    - stage: test
+      name: Docker image
+      script:
+        - ./.docker-travis.sh
+        - docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7-slim
+COPY . /oopt-gnpy
+WORKDIR /oopt-gnpy
+RUN python setup.py install
+WORKDIR /shared/examples
+ENTRYPOINT ["/oopt-gnpy/.docker-entry.sh"]
+CMD "/bin/bash"


### PR DESCRIPTION
A third, independent job in Travis CI just for building a container
image (and testing it a little bit). Here's how to use it once it is
built and published and pulled:

```shell-session
  $ docker run -it --rm --volume $(pwd):/shared telecominfraproject/oopt-gnpy
```

One can also pass commands to it directly. Note that the *relative* path specifier given as `./` is required. One could possibly get around it by `$PATH` manipulation, but hey, I have to stop somewhere.

```shell-session
  $ docker run -it --rm --volume $(pwd):/shared telecominfraproject/oopt-gnpy ./transmission_main_example.py
```

Thanks to @ojnas for the `--volume` option trick and for that early non-overwriting copying for the `example/` directory.

The `install` phase in Travis CI is apparently common for all jobs in the build matrix (it's rather confusing what they call a "stage" and what is a "job" for them, and what their mutual relation is). Because there's no point in doing any kind of installation in case when we're building for Docker, let's just move the old `install` block into `script`. With just that, however, Travis adds an implicit `pip install -r requirements.txt` in an attempt at being helpful. In short, having completely different "stuff to be done as a check" is very painful with Travis.

The individual "script lines" in a job's `script` section are always executed, all of them, even if a previous one failed. That's why I moved the actual Docker invocation into an external shell script. When they were not in a shell script and the script lines contained `set -e`, then a failure of a particular command would cause the build to be marked as "errored" instead of "failed" within Travis. Also, the multiline if conditionals were rather painful to write.

One commit might end up in different branches. If that happens, the second build would overwrite the image tag in the docker registry, which is rather suboptimal. Let's try to fetch that image first, and only update the latest/stable tags if the image was already available beforehand.

Fixes #260 