### PR TITLE
Refactor printing

### DIFF
--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -168,7 +168,7 @@ def compute_path(network, equipment, pathreqlist):
         print(f'Computed path (roadms):{[e.uid for e in total_path  if isinstance(e, Roadm)]}\n')
 
         if total_path :
-            total_path = propagate(total_path,pathreq,equipment, show=False)
+            total_path = propagate(total_path,pathreq,equipment)
         else:
             total_path = []
         # we record the last tranceiver object in order to have th whole
@@ -205,7 +205,7 @@ def compute_path_with_disjunction(network, equipment, pathreqlist, pathlist):
         # print(f'{pathreq.baud_rate}   {pathreq.power}   {pathreq.spacing}   {pathreq.nb_channel}')
         if total_path :
             if pathreq.baud_rate is not None:
-                total_path = propagate(total_path,pathreq,equipment, show=False)
+                total_path = propagate(total_path,pathreq,equipment)
                 temp_snr01nm = round(mean(total_path[-1].snr+lin2db(pathreq.baud_rate/(12.5e9))),2)
                 if temp_snr01nm < pathreq.OSNR :
                     msg = f'\tWarning! Request {pathreq.request_id} computed path from {pathreq.source} to {pathreq.destination} does not pass with {pathreq.tsp_mode}\n' +\

--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -144,44 +144,6 @@ def load_requests(filename,eqpt_filename):
             json_data = loads(f.read())
     return json_data
 
-def compute_path(network, equipment, pathreqlist):
-
-    # This function is obsolete and not relevant with respect to network building: suggest either to correct
-    # or to suppress it
-    
-    path_res_list = []
-
-    for pathreq in pathreqlist:
-        #need to rebuid the network for each path because the total power
-        #can be different and the choice of amplifiers in autodesign is power dependant
-        #but the design is the same if the total power is the same
-        #TODO parametrize the total spectrum power so the same design can be shared
-        p_db = lin2db(pathreq.power*1e3)
-        p_total_db = p_db + lin2db(pathreq.nb_channel)
-        build_network(network, equipment, p_db, p_total_db)
-        pathreq.nodes_list.append(pathreq.destination)
-        #we assume that the destination is a strict constraint
-        pathreq.loose_list.append('strict')
-        print(f'Computing path from {pathreq.source} to {pathreq.destination}')
-        print(f'with path constraint: {[pathreq.source]+pathreq.nodes_list}') #adding first node to be clearer on the output
-        total_path = compute_constrained_path(network, pathreq)
-        print(f'Computed path (roadms):{[e.uid for e in total_path  if isinstance(e, Roadm)]}\n')
-
-        if total_path :
-            total_path = propagate(total_path,pathreq,equipment)
-        else:
-            total_path = []
-        # we record the last tranceiver object in order to have th whole
-        # information about spectrum. Important Note: since transceivers
-        # attached to roadms are actually logical elements to simulate
-        # performance, several demands having the same destination may use
-        # the same transponder for the performance simaulation. This is why
-        # we use deepcopy: to ensure each propagation is recorded and not
-        # overwritten
-
-        path_res_list.append(deepcopy(total_path))
-    return path_res_list
-
 def compute_path_with_disjunction(network, equipment, pathreqlist, pathlist):
     
     # use a list but a dictionnary might be helpful to find path bathsed on request_id

--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -167,6 +167,7 @@ def compute_path_with_disjunction(network, equipment, pathreqlist, pathlist):
         if total_path :
             if pathreq.baud_rate is not None:
                 total_path = propagate(total_path,pathreq,equipment)
+                # for el in total_path: print(el)
                 temp_snr01nm = round(mean(total_path[-1].snr+lin2db(pathreq.baud_rate/(12.5e9))),2)
                 if temp_snr01nm < pathreq.OSNR :
                     msg = f'\tWarning! Request {pathreq.request_id} computed path from {pathreq.source} to {pathreq.destination} does not pass with {pathreq.tsp_mode}\n' +\

--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -35,7 +35,6 @@ import gnpy.core.ansi_escapes as ansi_escapes
 from copy import copy, deepcopy
 from textwrap import dedent
 from math import ceil
-import time
 
 #EQPT_LIBRARY_FILENAME = Path(__file__).parent / 'eqpt_config.json'
 
@@ -263,7 +262,6 @@ def path_result_json(pathresult):
 
 
 if __name__ == '__main__':
-    start = time.time()
     args = parser.parse_args()
     basicConfig(level={2: DEBUG, 1: INFO, 0: CRITICAL}.get(args.verbose, DEBUG))
     logger.info(f'Computing path requests {args.service_filename} into JSON format')
@@ -331,8 +329,6 @@ if __name__ == '__main__':
     print('\x1b[1;34;40m'+f'Propagating on selected path'+ '\x1b[0m')
     propagatedpths = compute_path_with_disjunction(network, equipment, rqs, pths)
 
-    end = time.time()
-    print(f'computation time {end-start}')
     print('\x1b[1;34;40m'+f'Result summary'+ '\x1b[0m')
 
     header = ['req id', '  demand','  snr@bandwidth','  snr@0.1nm','  Receiver minOSNR', '  mode', '  Gbit/s' , '  nb of tsp pairs']

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -161,7 +161,7 @@ def main(network, equipment, source, destination, sim_params, req=None):
             print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f} dBm:')
         else:
             print(f'\nTransmission results:')
-        print(f'  Final GSNR (signal bw): {ansi_escapes.cyan}{mean(destination.snr):.02f} dB{ansi_escapes.reset}')
+        print(f'  Final SNR total (signal bw): {ansi_escapes.cyan}{mean(destination.snr):.02f} dB{ansi_escapes.reset}')
 
         #print(f'\n !!!!!!!!!!!!!!!!!     TEST POINT         !!!!!!!!!!!!!!!!!!!!!')
         #print(f'carriers ase output of {path[1]} =\n {list(path[1].carriers("out", "nli"))}')

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -153,7 +153,10 @@ def main(network, equipment, source, destination, sim_params, req=None):
             print(f'\nPropagating with input power = {lin2db(req.power*1e3):.2f}dBm :')
         else:
             print(f'\nPropagating in gain mode: power cannot be set manually')
-        infos = propagate2(path, req, equipment, show=len(power_range)==1)
+        infos = propagate2(path, req, equipment)
+        if len(power_range) == 1:
+            for elem in path[:-1]:
+                print(elem)
         if power_mode:
             print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f}dBm :')
         else:

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -150,19 +150,18 @@ def main(network, equipment, source, destination, sim_params, req=None):
     for dp_db in power_range:
         req.power = db2lin(pref_ch_db + dp_db)*1e-3
         if power_mode:
-            print(f'\nPropagating with input power = {lin2db(req.power*1e3):.2f}dBm :')
+            print(f'\nPropagating with input power = {ansi_escapes.cyan}{lin2db(req.power*1e3):.2f} dBm{ansi_escapes.reset}:')
         else:
-            print(f'\nPropagating in gain mode: power cannot be set manually')
+            print(f'\nPropagating in {ansi_escapes.cyan}gain mode{ansi_escapes.reset}: power cannot be set manually')
         infos = propagate2(path, req, equipment)
         if len(power_range) == 1:
-            for elem in path[:-1]:
+            for elem in path:
                 print(elem)
         if power_mode:
-            print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f}dBm :')
+            print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f} dBm:')
         else:
             print(f'\nTransmission results:')
-        #info message in gain mode
-        print(destination)
+        print(f'  Final GSNR (signal bw): {ansi_escapes.cyan}{mean(destination.snr):.02f} dB{ansi_escapes.reset}')
 
         #print(f'\n !!!!!!!!!!!!!!!!!     TEST POINT         !!!!!!!!!!!!!!!!!!!!!')
         #print(f'carriers ase output of {path[1]} =\n {list(path[1].carriers("out", "nli"))}')
@@ -183,8 +182,7 @@ def main(network, equipment, source, destination, sim_params, req=None):
                         'OSNR_ASE_signal_bw'    : round(mean(destination.osnr_ase),2),
                         'SNR_nli_signal_bw'     : round(mean(destination.osnr_nli),2),
                         'SNR_total_signal_bw'   : round(mean(destination.snr),2)
-                                })          
-        #info message in gain mode
+                                })
     write_csv(result_dicts, 'simulation_result.csv')
     return path, infos
 

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -133,7 +133,7 @@ def main(network, equipment, source, destination, sim_params, req=None):
         configure_network(network, sim_params)
 
     spans = [s.length for s in path if isinstance(s, RamanFiber) or isinstance(s, Fiber)]
-    print(f'\nThere are {len(spans)} fiber spans over {sum(spans):.0f}m between {source.uid} and {destination.uid}')
+    print(f'\nThere are {len(spans)} fiber spans over {sum(spans)/1000:.0f} km between {source.uid} and {destination.uid}')
     print(f'\nNow propagating between {source.uid} and {destination.uid}:')
 
     try:

--- a/gnpy/core/ansi_escapes.py
+++ b/gnpy/core/ansi_escapes.py
@@ -9,4 +9,5 @@ A random subset of ANSI terminal escape codes for colored messages
 '''
 
 red = '\x1b[1;31;40m'
+cyan = '\x1b[1;36;40m'
 reset = '\x1b[0m'

--- a/gnpy/core/request.py
+++ b/gnpy/core/request.py
@@ -393,18 +393,16 @@ def compute_constrained_path(network, req):
 
     return total_path
 
-def propagate(path, req, equipment, show=False):
+def propagate(path, req, equipment):
     si = create_input_spectral_information(
         req.f_min, req.f_max, req.roll_off, req.baud_rate,
         req.power, req.spacing)
     for el in path:
         si = el(si)
-        if show :
-            print(el)
     path[-1].update_snr(req.tx_osnr, equipment['Roadm']['default'].add_drop_osnr)
     return path
 
-def propagate2(path, req, equipment, show=False):
+def propagate2(path, req, equipment):
     si = create_input_spectral_information(
         req.f_min, req.f_max, req.roll_off, req.baud_rate,
         req.power, req.spacing)
@@ -413,12 +411,10 @@ def propagate2(path, req, equipment, show=False):
         before_si = si
         after_si  = si = el(si)
         infos[el] = before_si, after_si
-        if show :
-            print(el)
     path[-1].update_snr(req.tx_osnr, equipment['Roadm']['default'].add_drop_osnr)
     return infos
 
-def propagate_and_optimize_mode(path, req, equipment, show=False):
+def propagate_and_optimize_mode(path, req, equipment):
     # if mode is unknown : loops on the modes starting from the highest baudrate fiting in the
     # step 1: create an ordered list of modes based on baudrate
     baudrate_to_explore = list(set([m['baud_rate'] for m in equipment['Transceiver'][req.tsp].mode 
@@ -442,8 +438,6 @@ def propagate_and_optimize_mode(path, req, equipment, show=False):
             b, req.power, req.spacing)
             for el in path:
                 si = el(si)
-                if show:
-                    print(el)
             for m in modes_to_explore :
                 if path[-1].snr is not None:
                     path[-1].update_snr(m['tx_osnr'], equipment['Roadm']['default'].add_drop_osnr)

--- a/tests/test_automaticmodefeature.py
+++ b/tests/test_automaticmodefeature.py
@@ -72,7 +72,7 @@ def test_automaticmodefeature(net,eqpt,serv,expected_mode):
         if pathreq.baud_rate is not None:
             print(pathreq.format)
             path_res_list.append(pathreq.format)
-            total_path = propagate(total_path,pathreq,equipment, show=False)
+            total_path = propagate(total_path,pathreq,equipment)
         else:
             total_path,mode = propagate_and_optimize_mode(total_path,pathreq,equipment)
             # if no baudrate satisfies spacing, no mode is returned and an empty path is returned


### PR DESCRIPTION
(This replaces #261 by me and #293 by Jonas.)

##     Remove debug printing from propagate()
This is inspired by #293. The original issue was that the transponder OSNR was not accounted for. Rather than making the `propagate()` and `propagate2()` more complex, let's move the actual path printing to the demo code. There's no secret sauce in there, it's just a simple for-each-print thingy, so let's remove it from the library code.
    
fixes #262

## doc: fiber length summary in km, not meters

Reading `80000m` is a bit more complex than just `80 km`. Also let's add a space between the numebr and the unit for better readability.

## examples: color highlighting of the "most interesting output"
    
I think that this SNR value represents the most important output of this  example. There's plenty of debugging info on display already, so let's make this one more prominent.
    
I was thinking about moving the highlighting to elements' each `__str__()` function, but that felt a bit like layering violation to me. I could have also changed just the transponder's `__str__()`. In the end, I think that repeating just the final GSNR at the link-end transponder makes most sense here. This is aligned with what we talked about at yesterday's (on 2019-09-18 -- note that this is a backport from #261) demo for Microsoft, after all.