### PR TITLE
docs: Document Transceiver.mode.OSNR

### DIFF
--- a/json_structure_description.rst
+++ b/json_structure_description.rst
@@ -273,6 +273,8 @@ Spectral information with its parameters:
 Transceiver element with its parameters. **”mode”** can contain multiple
 Transceiver operation formats.
 
+Note that ``OSNR`` parameter refers to the receiver's minimal OSNR threshold for a given mode.
+
 .. code-block:: json-object
 
     "Transceiver":[{


### PR DESCRIPTION
I am not changing the JSON key name now because of the plan to go with a full-blown YANG model (see #266).

fixes #298