### PR TITLE
Rework OSNR printing

### DIFF
--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -161,7 +161,7 @@ def main(network, equipment, source, destination, sim_params, req=None):
             print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f} dBm:')
         else:
             print(f'\nTransmission results:')
-        print(f'  Final SNR total (signal bw): {ansi_escapes.cyan}{mean(destination.snr):.02f} dB{ansi_escapes.reset}')
+        print(f'  Final SNR total (0.1 nm): {ansi_escapes.cyan}{mean(destination.snr_01nm):.02f} dB{ansi_escapes.reset}')
 
         #print(f'\n !!!!!!!!!!!!!!!!!     TEST POINT         !!!!!!!!!!!!!!!!!!!!!')
         #print(f'carriers ase output of {path[1]} =\n {list(path[1].carriers("out", "nli"))}')

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -157,13 +157,13 @@ def main(network, equipment, source, destination, sim_params, req=None):
         if len(power_range) == 1:
             for elem in path:
                 print(elem)
+            if power_mode:
+                print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f} dBm:')
+            else:
+                print(f'\nTransmission results:')
+            print(f'  Final SNR total (0.1 nm): {ansi_escapes.cyan}{mean(destination.snr_01nm):.02f} dB{ansi_escapes.reset}')
         else:
             print(path[-1])
-        if power_mode:
-            print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f} dBm:')
-        else:
-            print(f'\nTransmission results:')
-        print(f'  Final SNR total (0.1 nm): {ansi_escapes.cyan}{mean(destination.snr_01nm):.02f} dB{ansi_escapes.reset}')
 
         #print(f'\n !!!!!!!!!!!!!!!!!     TEST POINT         !!!!!!!!!!!!!!!!!!!!!')
         #print(f'carriers ase output of {path[1]} =\n {list(path[1].carriers("out", "nli"))}')

--- a/examples/transmission_main_example.py
+++ b/examples/transmission_main_example.py
@@ -157,6 +157,8 @@ def main(network, equipment, source, destination, sim_params, req=None):
         if len(power_range) == 1:
             for elem in path:
                 print(elem)
+        else:
+            print(path[-1])
         if power_mode:
             print(f'\nTransmission result for input power = {lin2db(req.power*1e3):.2f} dBm:')
         else:


### PR DESCRIPTION
Esther and Jonas pointed out that it is much more common to work with OSNR measurements per 0.1nm rather than per signal bandwidth. This is in line with what OSAs usually report and what transponder datasheets specify.

cc #307