### PR TITLE
add the option "rest" to activate the api-rest

### DIFF
--- a/examples/path_requests_run.py
+++ b/examples/path_requests_run.py
@@ -23,7 +23,7 @@ from networkx import (draw_networkx_nodes, draw_networkx_edges,
 from numpy import mean
 from gnpy.core.service_sheet import convert_service_sheet, Request_element, Element
 from gnpy.core.utils import load_json
-from gnpy.core.network import load_network, build_network, save_network
+from gnpy.core.network import load_network, network_from_json, build_network, save_network
 from gnpy.core.equipment import load_equipment, trx_mode_params, automatic_nch, automatic_spacing
 from gnpy.core.elements import Transceiver, Roadm, Edfa, Fused, Fiber
 from gnpy.core.utils import db2lin, lin2db
@@ -36,7 +36,15 @@ from copy import copy, deepcopy
 from textwrap import dedent
 from math import ceil
 
+from flask import Flask, jsonify, abort, make_response, request
+from flask_restful import Api, Resource, reqparse, fields, marshal
+from flask_httpauth import HTTPBasicAuth
+
 #EQPT_LIBRARY_FILENAME = Path(__file__).parent / 'eqpt_config.json'
+
+app = Flask(__name__, static_url_path="")
+api = Api(app)
+auth = HTTPBasicAuth()
 
 logger = getLogger(__name__)
 
@@ -46,7 +54,7 @@ parser.add_argument('service_filename', nargs='?', type = Path, default= Path(__
 parser.add_argument('eqpt_filename', nargs='?', type = Path, default=Path(__file__).parent / 'eqpt_config.json')
 parser.add_argument('-v', '--verbose', action='count', default=0, help='increases verbosity for each occurence')
 parser.add_argument('-o', '--output', type = Path)
-
+parser.add_argument('-r', '--rest', action='count', default=0, help='use the REST API')
 
 def requests_from_json(json_data,equipment):
     requests_list = []
@@ -261,28 +269,7 @@ def path_result_json(pathresult):
     }
     return data
 
-
-if __name__ == '__main__':
-    args = parser.parse_args()
-    basicConfig(level={2: DEBUG, 1: INFO, 0: CRITICAL}.get(args.verbose, DEBUG))
-    logger.info(f'Computing path requests {args.service_filename} into JSON format')
-    print('\x1b[1;34;40m'+f'Computing path requests {args.service_filename} into JSON format'+ '\x1b[0m')
-    # for debug
-    # print( args.eqpt_filename)
-    try:
-        data = load_requests(args.service_filename,args.eqpt_filename)
-        equipment = load_equipment(args.eqpt_filename)
-        network = load_network(args.network_filename,equipment)
-    except EquipmentConfigError as e:
-        print(f'{ansi_escapes.red}Configuration error in the equipment library:{ansi_escapes.reset} {e}')
-        exit(1)
-    except NetworkTopologyError as e:
-        print(f'{ansi_escapes.red}Invalid network definition:{ansi_escapes.reset} {e}')
-        exit(1)
-    except ConfigurationError as e:
-        print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')
-        exit(1)
-
+def compute_requests(network,data,equipment):
     # Build the network once using the default power defined in SI in eqpt config
     # TODO power density : db2linp(ower_dbm": 0)/power_dbm": 0 * nb channels as defined by
     # spacing, f_min and f_max
@@ -309,25 +296,25 @@ if __name__ == '__main__':
     # pths = compute_path(network, equipment, rqs)
     dsjn = disjunctions_from_json(data)
 
-    print('\x1b[1;34;40m'+f'List of disjunctions'+ '\x1b[0m')
+    print('\x1b[1;34;40m' + f'List of disjunctions' + '\x1b[0m')
     print(dsjn)
     # need to warn or correct in case of wrong disjunction form
     # disjunction must not be repeated with same or different ids
     dsjn = correct_disjn(dsjn)
 
     # Aggregate demands with same exact constraints
-    print('\x1b[1;34;40m'+f'Aggregating similar requests'+ '\x1b[0m')
+    print('\x1b[1;34;40m' + f'Aggregating similar requests' + '\x1b[0m')
 
-    rqs,dsjn = requests_aggregation(rqs,dsjn)
+    rqs, dsjn = requests_aggregation(rqs, dsjn)
     # TODO export novel set of aggregated demands in a json file
 
-    print('\x1b[1;34;40m'+'The following services have been requested:'+ '\x1b[0m')
+    print('\x1b[1;34;40m' + 'The following services have been requested:' + '\x1b[0m')
     print(rqs)
 
-    print('\x1b[1;34;40m'+f'Computing all paths with constraints'+ '\x1b[0m')
+    print('\x1b[1;34;40m' + f'Computing all paths with constraints' + '\x1b[0m')
     pths = compute_path_dsjctn(network, equipment, rqs, dsjn)
 
-    print('\x1b[1;34;40m'+f'Propagating on selected path'+ '\x1b[0m')
+    print('\x1b[1;34;40m' + f'Propagating on selected path' + '\x1b[0m')
     propagatedpths = compute_path_with_disjunction(network, equipment, rqs, pths)
 
     print('\x1b[1;34;40m'+f'Result summary'+ '\x1b[0m')
@@ -347,13 +334,31 @@ if __name__ == '__main__':
     col_width = max(len(word) for row in data for word in row[2:])   # padding
     firstcol_width = max(len(row[0]) for row in data )   # padding
     secondcol_width = max(len(row[1]) for row in data )   # padding
+
     for row in data:
         firstcol = ''.join(row[0].ljust(firstcol_width))
         secondcol = ''.join(row[1].ljust(secondcol_width))
-        remainingcols = ''.join(word.center(col_width,' ') for word in row[2:])
+        remainingcols = ''.join(word.center(col_width, ' ') for word in row[2:])
         print(f'{firstcol} {secondcol} {remainingcols}')
 
+    print('\x1b[1;33;40m'+f'Result summary shows mean SNR and OSNR (average over all channels)'+ '\x1b[0m')
 
+    return propagatedpths,rqs
+
+
+def launch_cli():
+    args = parser.parse_args()
+    basicConfig(level={2: DEBUG, 1: INFO, 0: CRITICAL}.get(args.verbose, DEBUG))
+    logger.info(f'Computing path requests {args.service_filename} into JSON format')
+    print('\x1b[1;34;40m'+f'Computing path requests {args.service_filename} into JSON format'+ '\x1b[0m')
+    # for debug
+    # print( args.eqpt_filename)
+    data = load_requests(args.service_filename,args.eqpt_filename)
+    equipment = load_equipment(args.eqpt_filename)
+    network = load_network(args.network_filename,equipment)
+    #Compute requests using network, data and equipment
+    propagatedpths, rqs = compute_requests(network,data,equipment)
+    #Generate the output
     if args.output :
         result = []
         # assumes that list of rqs and list of propgatedpths have same order
@@ -367,3 +372,74 @@ if __name__ == '__main__':
             with open(fnamecsv,"w", encoding='utf-8') as fcsv :
                 jsontocsv(temp,equipment,fcsv)
                 print('\x1b[1;34;40m'+f'saving in {args.output} and {fnamecsv}'+ '\x1b[0m')
+
+class GnpyAPI(Resource):
+    decorators = [auth.login_required]
+    @auth.get_password
+    def get_password(username):
+        if username == 'gnpy':
+            return 'gnpy'
+        return None
+
+    @auth.error_handler
+    def unauthorized():
+        # return 403 instead of 401 to prevent browsers from displaying the default
+        # auth dialog
+        return make_response(jsonify({'message': 'Unauthorized access'}), 403)
+
+    def post(self):
+        print (request.is_json)
+        content = request.get_json()
+        content1 = content['gnpy-api']
+        topoJson = content1['topology-file']
+        svcJson = content1['service-file']
+        # Load equipment
+        equipment = load_equipment('eqpt_config.json')
+        #Create load_requests
+        data = svcJson
+        #network = load_network(args.network_filename, equipment)
+        network = network_from_json(topoJson, equipment)
+        # Compute requests using network, data and equipment
+        propagatedpths, rqs = compute_requests(network, data, equipment)
+        # Generate the output
+        result = []
+        #assumes that list of rqs and list of propgatedpths have same order
+        for i, p in enumerate(propagatedpths):
+            result.append(Result_element(rqs[i], p))
+
+        return {"result":path_result_json(result)}, 201
+
+api.add_resource(GnpyAPI, '/gnpy/api/v1.0/files', endpoint='files')
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    basicConfig(level={2: DEBUG, 1: INFO, 0: CRITICAL}.get(args.verbose, DEBUG))
+    logger.info(f'Computing path requests {args.service_filename} into JSON format')
+    print('\x1b[1;34;40m'+f'Computing path requests {args.service_filename} into JSON format'+ '\x1b[0m')
+    # for debug
+    # print( args.eqpt_filename)
+    try:
+        data = load_requests(args.service_filename,args.eqpt_filename)
+        equipment = load_equipment(args.eqpt_filename)
+        network = load_network(args.network_filename,equipment)
+    except EquipmentConfigError as e:
+        print(f'{ansi_escapes.red}Configuration error in the equipment library:{ansi_escapes.reset} {e}')
+        exit(1)
+    except NetworkTopologyError as e:
+        print(f'{ansi_escapes.red}Invalid network definition:{ansi_escapes.reset} {e}')
+        exit(1)
+    except ConfigurationError as e:
+        print(f'{ansi_escapes.red}Configuration error:{ansi_escapes.reset} {e}')
+        exit(1)
+
+    # input_str = raw_input("How will you use your program: c:[cli] , a:[api] ?")
+    # print(input_str)
+    #
+    if ((args.rest == 1) and (args.output is None)):
+        print('you have chosen the rest mode')
+        app.run(host='0.0.0.0', port=5000, debug=True)
+    elif ((args.rest > 1) or ((args.rest == 1) and (args.output is not None))):
+        print('command is not well formulated')
+    else:
+        launch_cli()

--- a/path_result_template.json
+++ b/path_result_template.json
@@ -1,40 +1,179 @@
 {
-  "paths": [
+  "response": [
     {
-      "path": {
-        "path-id": null,
-        "path-properties": {
-          "path-metric": [
-            {
-              "metric-type": null,
-              "accumulative-value": null
-            }
-          ],
-          "path-srlgs": {
-            "usage": "not used yet",
-            "values": ["not used yet"]
+      "response-id": "string same id as for the request",
+      "path-properties": {
+        "path-metric": [
+          {
+            "metric-type": "SNR-bandwidth",
+            "accumulative-value": 17.53  decimal values
           },
-          "path-route-objects": [
-            {
-              "path-route-object": {
-                "index": null,
-                "unnumbered-hop": {
-                  "node-id": null,
-                  "link-tp-id": null,
-                  "hop-type": null,
-                  "direction": "not used"
-                },
-                "label-hop": {
-                  "te-label": {
-                    "generic": "not used yet",
-                    "direction": "not used yet"
-                  }
+          {
+            "metric-type": "SNR-0.1nm",
+            "accumulative-value": 21.61
+          },
+          {
+            "metric-type": "OSNR-bandwidth",
+            "accumulative-value": 19.34
+          },
+          {
+            "metric-type": "OSNR-0.1nm",
+            "accumulative-value": 23.42
+          },
+          {
+            "metric-type": "reference_power",
+            "accumulative-value": 0.001
+          },
+          {
+            "metric-type": "path_bandwidth",
+            "accumulative-value": 1000000000000.0
+          }
+        ],
+        "path-route-objects": [  list of hop, label, transponder
+          {
+            "path-route-object": {
+              "index": 0,
+              "num-unnum-hop": {
+                "node-id": "trx Rennes_STA",
+                "link-tp-id": "trx Rennes_STA"
+              }
+            }
+          },
+          {
+            "path-route-object": {
+              "index": 1,
+              "label-hop": {
+                "N": -248,
+                "M": 40
+              }
+            }
+          },
+          {
+            "path-route-object": {
+              "index": 2,
+              "transponder": {
+                "transponder-type": "Voyager",
+                "transponder-mode": "mode 1"
+              }
+            }
+          },
+          {
+            "path-route-object": {
+              "index": 3,
+              "num-unnum-hop": {
+                "node-id": "roadm Rennes_STA",
+                "link-tp-id": "roadm Rennes_STA"
+              }
+            }
+          },
+          {
+            "path-route-object": {
+              "index": 4,
+              "label-hop": {
+                "N": -248,
+                "M": 40
+              }
+            }
+          },
+          {
+            "path-route-object": {
+              "index": 5,
+              "num-unnum-hop": {
+                "node-id": "Edfa1_roadm Rennes_STA",
+                "link-tp-id": "Edfa1_roadm Rennes_STA"
+              }
+            }
+          },
+          {
+            "path-route-object": {
+              "index": 6,
+              "label-hop": {
+                "N": -248,
+                "M": 40
+              }
+            }
+          },
+          {
+            "path-route-object": {
+              "index": 7,
+              "num-unnum-hop": {
+                "node-id": "fiber (Rennes_STA → Ploermel)-",
+                "link-tp-id": "fiber (Rennes_STA → Ploermel)-"
+              }
+            }
+          },
+        ...
+        ]
+      }
+    },
+    {
+      "path-id": "7c",
+      "path-properties": {
+        "path-metric": [
+          {
+            "metric-type": "SNR@bandwidth",
+            "accumulative-value": "None"
+          },
+          {
+            "metric-type": "SNR@0.1nm",
+            "accumulative-value": "None"
+          },
+          {
+            "metric-type": "OSNR@bandwidth",
+            "accumulative-value": "None"
+          },
+          {
+            "metric-type": "OSNR@0.1nm",
+            "accumulative-value": "None"
+          },
+          {
+            "metric-type": "reference_power",
+            "accumulative-value": 0.001
+          },
+          {
+            "metric-type": "path_bandwidth",
+            "accumulative-value": 400000000000.0
+          }
+        ],
+        "path-srlgs": {
+          "usage": "not used yet",
+          "values": "not used yet"
+        },
+        "path-route-objects": [
+          {
+            "path-route-object": {
+              "index": 0,
+              "unnumbered-hop": {
+                "node-id": "trx Lannion_CAS",
+                "link-tp-id": "trx Lannion_CAS",
+                "hop-type": "Voyager - not feasible with this transponder",
+                "direction": "not used"
+              },
+              "label-hop": {
+                "te-label": {
+                  "generic": "not used yet",
+                  "direction": "not used yet"
                 }
               }
             }
-          ]
-        }
+          },
+          {
+            "path-route-object": {
+              "index": 1,
+              "unnumbered-hop": {
+                "node-id": "trx Lorient_KMA",
+                "link-tp-id": "trx Lorient_KMA",
+                "hop-type": "Voyager - not feasible with this transponder",
+                "direction": "not used"
+              },
+              "label-hop": {
+                "te-label": {
+                  "generic": "not used yet",
+                  "direction": "not used yet"
+                }
+              }
+            }
+          }
+        ]
       }
-    }
-  ]
-}
+    },      

--- a/service-template.json
+++ b/service-template.json
@@ -1,60 +1,57 @@
 {
   "path-request": [
-    {
-      "request-id": null,
-      "source": null,
-      "destination": null,
-      "src-tp-id": null,
-      "dst-tp-id": null,
+   {
+      "request-id": "string",
+      "source": "roadm name",
+      "destination": "roadm name",
+      "src-tp-id": "trx name",
+      "dst-tp-id": "trx name",
       "path-constraints": {
         "te-bandwidth": {
           "technology": "flexi-grid",
-          "trx_type": null,
-          "trx_mode": null,
+          "trx_type": "name of the tsp type_variety as listed in the library",
+          "trx_mode": "optional, name of the mode as listed in the tsp type_variety",
           "effective-freq-slot": [
             {
               "n": "null",
               "m": "null"
             }
           ],
-          "spacing": null,
-          "max-nb-of-channel": null,
-          "output-power": null,
-          "path_bandwidth": null
-          }
+          "spacing": mandatory 50000000000.0,
+          "max-nb-of-channel": optional 80,
+          "output-power": optional 0.0012589254117941673,
+          "path_bandwidth": optional 100000000000.0
+        }
       },
       "optimizations": {
-        "explicit-route-include-objects": {
-          "route-object-include-object": [
-          {
-            "index": null,
-            "unnumbered-hop": {
-              "node-id": null,
-              "link-tp-id": "link-tp-id is not used",
-              "hop-type": null,
-              "direction": "direction is not used"
-            },
-            "label-hop": {
-              "te-label": {
-                "generic": "generic is not used",
-                "direction": "direction is not used"
-              }
-            }
-          }
-          ]
-        }
+        "explicit-route-include-objects": [] if no constraint or list of object if constraints
       }
-    }],
-  "synchronization": [
+    },
+  ],
+  "synchronization": [   list of disjunctions
     {
-      "synchronization-id": null,
+      "synchronization-id": "3",
       "svec": {
-        "relaxable": "True",
-        "link-diverse": "False",
-        "node-diverse": "False",
+        "relaxable": "False",
+        "link-diverse": "True",
+        "node-diverse": "True",
         "request-id-number": [
-         null ]
-        },
+          "3",
+          "1"
+        ]
+      }
+    },
+    {
+      "synchronization-id": "4",
+      "svec": {
+        "relaxable": "False",
+        "link-diverse": "True",
+        "node-diverse": "True",
+        "request-id-number": [
+          "4",
+          "5"
+        ]
+      }
     }
-    ]
+  ]  
 }


### PR DESCRIPTION
On behalf of @ahmed-triki 
This is an implementation of an API rest for GNPy. The http server is based on flask, so the installation of this package is mandatory. The input/output of the api-rest are modeled by a yang data model.
In addition to the Rest mode, the new code keeps the possibility to use the current CLI (Command Line Interface) mode.
To activate the Rest mode, the user has to launch the following command :
python path_requests_run.py --rest
The API-rest client has to take into account the following connection parameters:

    URL: http://<ip_address>:5000/gnpy/api/v1.0/files
    authentication: username: gnpy/ password: gnpy
    Rest-Method: POST / The body of the request is composed of the topology and the service data in json format.
    
    Todo: add explanation of the body and the response models of the API-REST.

-------
- add the function launch_cli to launch the "cli" mode
- add the the class Gnpy_API to launch the "api" mode
- modify the main to enable the launch of Gnpy with two
modes "rest" and "cli"

Signed-off-by: ahmed <ahmed.triki@orange.com>