### PR TITLE
Small refactoring for itufs/utifl

### DIFF
--- a/gnpy/core/elements.py
+++ b/gnpy/core/elements.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 
 from gnpy.core.node import Node
 from gnpy.core.units import UNITS
-from gnpy.core.utils import lin2db, db2lin, itufs, itufl, snr_sum
+from gnpy.core.utils import lin2db, db2lin, itufl, snr_sum
 from gnpy.core.science_utils import propagate_raman_fiber, _psi
 
 class Transceiver(Node):

--- a/gnpy/core/elements.py
+++ b/gnpy/core/elements.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 
 from gnpy.core.node import Node
 from gnpy.core.units import UNITS
-from gnpy.core.utils import lin2db, db2lin, itufl, snr_sum
+from gnpy.core.utils import lin2db, db2lin, arrange_frequencies, snr_sum
 from gnpy.core.science_utils import propagate_raman_fiber, _psi
 
 class Transceiver(Node):
@@ -615,7 +615,7 @@ class Edfa(Node):
                 self.channel_freq, self.nf, self.interpol_dgt and self.interpol_gain_ripple
         """
         # TODO|jla: read amplifier actual frequencies from additional params in json
-        amplifier_freq = itufl(len(self.params.dgt), self.params.f_min, self.params.f_max) # Hz
+        amplifier_freq = arrange_frequencies(len(self.params.dgt), self.params.f_min, self.params.f_max) # Hz
         self.channel_freq = frequencies
         self.interpol_dgt = interp(self.channel_freq, amplifier_freq, self.params.dgt)
 

--- a/gnpy/core/utils.py
+++ b/gnpy/core/utils.py
@@ -73,9 +73,8 @@ def c():
     return constants.c
 
 
-def itufl(length, startf=191.35, stopf=196.10):
-    """Creates an array of frequencies whose default range is
-    191.35-196.10 THz
+def itufl(length, startf, stopf):
+    """Create an array of frequencies
 
     :param length: number of elements
     :param starf: Start frequency in THz

--- a/gnpy/core/utils.py
+++ b/gnpy/core/utils.py
@@ -73,21 +73,6 @@ def c():
     return constants.c
 
 
-def itufs(spacing, startf=191.35, stopf=196.10):
-    """Creates an array of frequencies whose default range is
-    191.35-196.10 THz
-
-    :param spacing: Frequency spacing in THz
-    :param starf: Start frequency in THz
-    :param stopf: Stop frequency in THz
-    :type spacing: float
-    :type startf: float
-    :type stopf: float
-    :return an array of frequnecies determined by the spacing parameter
-    :rtype: numpy.ndarray
-    """
-    return np.arange(startf, stopf + spacing / 2, spacing)
-
 def itufl(length, startf=191.35, stopf=196.10):
     """Creates an array of frequencies whose default range is
     191.35-196.10 THz

--- a/gnpy/core/utils.py
+++ b/gnpy/core/utils.py
@@ -73,19 +73,19 @@ def c():
     return constants.c
 
 
-def itufl(length, startf, stopf):
+def arrange_frequencies(length, start, stop):
     """Create an array of frequencies
 
     :param length: number of elements
-    :param starf: Start frequency in THz
-    :param stopf: Stop frequency in THz
+    :param star: Start frequency in THz
+    :param stop: Stop frequency in THz
     :type length: integer
-    :type startf: float
-    :type stopf: float
-    :return an array of frequnecies determined by the spacing parameter
+    :type start: float
+    :type stop: float
+    :return an array of frequencies determined by the spacing parameter
     :rtype: numpy.ndarray
     """
-    return np.linspace(startf, stopf, length)
+    return np.linspace(start, stop, length)
 
 def h():
     """


### PR DESCRIPTION
- nuked the unused `itufs`
- better name for the former `itufl`
- remove `itufl`'s defaults, rework the help, etc