### PR TITLE
build: workaround Sphinx doc build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alabaster>=0.7.12,<1
+docutils==0.15.2
 matplotlib>=3.1.0,<4
 networkx>=2.3,<3
 numpy>=1.16.1,<2


### PR DESCRIPTION
Upstream bugreport at sphinx-doc/sphinx#6887 suggests that this is due to pip picking up the 0.16b0.dev0 pre-release...

This is deliberately done on master because this failure affects all branches.