### PR TITLE
travis: allow building a specific ref via a webhook

### DIFF
--- a/.gerrit+travis.sh
+++ b/.gerrit+travis.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+if [[ -n "${GERRIT_REF}" ]]; then
+  git fetch https://review.gerrithub.io/Telecominfraproject/oopt-gnpy "${GERRIT_REF}"
+  git reset --hard FETCH_HEAD
+  echo "Gerrit change: ${GERRIT_REF}: $(git rev-parse HEAD)"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.7"
 install: skip
 script:
+  - ./.gerrit+travis.sh
   - python setup.py install
   - pip install pytest-cov rstcheck
   - pytest --cov-report=xml --cov=gnpy


### PR DESCRIPTION
### Do not merge this, I'll direct-push to a throwaway branch once it passes testing.

This is needed if we want to use GerritHub with Travis-CI. Travis has an API [which makes it possible to trigger builds](https://docs.travis-ci.com/user/triggering-builds), but the branch specifier is fed directly to a `git clone --branch=` (see the [logs](https://travis-ci.com/Telecominfraproject/oopt-gnpy/jobs/273172925)). Therefore passing something like `refs/changes/...` just does not work.

This change should, hopefully, allow triggering the build as, e.g.:

```sh
curl -s -X POST -H "Content-Type: application/json" \
  -H "Accept: application/json" -H "Travis-API-Version: 3" \
  -H "Authorization: token XXX" \
  -d '{"request":{"branch":"develop","config":{"env":{"jobs":["GERRIT_REF=refs/changes/79/479579/2"]}}}}' \
  https://api.travis-ci.com/repo/Telecominfraproject%2Foopt-gnpy/requests
```