### PR TITLE
Fix test failure due to mishandled merge

### DIFF
--- a/tests/test_amplifier.py
+++ b/tests/test_amplifier.py
@@ -167,7 +167,7 @@ def test_ase_noise(gain, si, setup_trx, bw):
     span = next(n for n in network.nodes() if n.uid == 'Span1')
     # update span1 and Edfa1 according to new gain before building network
     # updating span 1  avoids to overload amp
-    span.length = gain*1e3 / 0.2
+    span.params.length = gain*1e3 / 0.2
     edfa.operational.gain_target = gain
     build_network(network, equipment,0, 20)
     edfa.gain_ripple = zeros(96)


### PR DESCRIPTION
In commit 80eced8, the structure of parameters to `elements.Fiber` was changed. Options such as fiber length are now passed in via `self.parameters.*` instead of `self.*`. Commit 639b379 which fixed a test failure precedes that change, and when we merge both as I did in commit bc4b664, the test no longer works. My bad. On the other hand, this will be caught by [trunk gating](https://zuul-ci.org/docs/zuul/discussion/gating.html) which is something that Zuul can do, and therefore something that we'll have in our upcoming CI, yay!

Fixes: bc4b664 #340