### PR TITLE
Fix dependency installation with PBR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.7"
 install: skip
 script:
-  - python setup.py install
+  - python setup.py develop
   - pip install pytest-cov rstcheck
   - pytest --cov-report=xml --cov=gnpy
   - rstcheck --ignore-roles cite --ignore-directives automodule --recursive --ignore-messages '(Duplicate explicit target name.*)' .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.7-slim
 COPY . /oopt-gnpy
 WORKDIR /oopt-gnpy
-RUN python setup.py install
+RUN apt update; apt install -y git
+RUN pip install .
 WORKDIR /shared/examples
 ENTRYPOINT ["/oopt-gnpy/.docker-entry.sh"]
 CMD ["/bin/bash"]

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ of the `gnpy` repo and install it with:
 
     $ git clone https://github.com/Telecominfraproject/oopt-gnpy # clone the repo
     $ cd oopt-gnpy
-    $ python setup.py install                                    # install
+    $ python setup.py develop
 
 To test that `gnpy` was successfully installed, you can run this command. If it
 executes without a ``ModuleNotFoundError``, you have successfully installed


### PR DESCRIPTION
Ouch, this one hurts. It turns out that PBR-based setup does *not* install all dependencies when running `python setup.py install`. On the other hand, running any of:

- `pip install .`
- `pip install --editable .`
- `python setup.py develop`

...makes everything work. So, let's change the instructions and all the
build scripts (including the Docker file) to make sure this thing still
works. Sorry for noise.

This is a significant change, it means that people will have "in-place
installations" of GNPy. Changes to their git checkouts, if used, will
apply, etc. I think this is actually a good change.

fixes #287

TL;DR: package installation with Python is still a mess.