### PR TITLE
Install via PIP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-sudo: false
+os: linux
 language: python
 services: docker
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services: docker
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 install: skip
 script:
   - pip install --editable .

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.7"
 install: skip
 script:
-  - python setup.py develop
+  - pip install --editable .
   - pip install pytest-cov rstcheck
   - pytest --cov-report=xml --cov=gnpy -v
   - rstcheck --ignore-roles cite *.rst

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -98,7 +98,7 @@ of the `gnpy` repo and install it with:
 
     $ git clone https://github.com/Telecominfraproject/oopt-gnpy # clone the repo
     $ cd oopt-gnpy
-    $ python setup.py develop
+    $ pip install --editable .
 
 To test that `gnpy` was successfully installed, you can run this command. If it
 executes without a ``ModuleNotFoundError``, you have successfully installed


### PR DESCRIPTION
There are several differences between `python setup.py develop` and `pip
install --editable .` ; one which became relevant a few days ago is the fact that `python setup.py develop` is apparently happy to pull in pre-releases of our dependencies -- perhaps due to the fact that this package, when installed from git, is also considered a pre-release. This has led to CI failures in Travis, and for some reason just on Python 3.6, not on Python 3.7.

This is of course rather ugly, and there's no need to start pulling in pre-releases of various pieces of software that we're using, anyway. Fix this by asking our users to use PIP, and adjusting the CI accordingly. Zuul CI uses tox which is documented to call PIP behind the scenes, so there's no change in there.

Fixes: https://travis-ci.com/github/Telecominfraproject/oopt-gnpy/jobs/353680894