### PR TITLE
Bumpy numpy for Travis CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alabaster>=0.7.12,<1
 docutils==0.15.2
 matplotlib>=3.1.0,<4
 networkx>=2.3,<3
-numpy>=1.16.1,<2
+numpy>=1.19.4,<2
 pandas>=1.0.5,<2
 pbr>=5.4.4,<6
 Pygments>=2.4.2,<3


### PR DESCRIPTION
On Travis, builds with Python 3.7 started failing recently:

```
 ERROR: pandas 1.2.0 has requirement numpy>=1.16.5, but you'll have numpy 1.16.4 which is incompatible.
 ERROR: scipy 1.6.0 has requirement numpy>=1.16.5, but you'll have numpy 1.16.4 which is incompatible.
```

Apparently the version of numpy that gets used when under Travis is rather different among their Python versions, and we get:

- numpy-1.19.4 in their Python 3.8.6 env,
- numpy-1.19.0 on 3.6.7,
- numpy-1.16.4 on 3.7.1

That's a bit insane to my liking, perhaps they're preloading popular libs such as numpy into their images for speed ups? For comparison, on Zuul CI we have this:

- numpy-1.19.4 with Python 3.8.6 on Fedora 32,
- numpy-1.19.4 with Python 3.6.8 on CentOS 8

Let's start requiring numpy 1.19.4 everywhere. This is the cost we're paying for https://github.com/Telecominfraproject/oopt-gnpy/pull/268 .

Change-Id: I6f1167096cfadc415cf456ad09ff0a08b535fc08