### PR TITLE
Rollback numpy to 1.19.3 for temporary Window Runtime Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alabaster>=0.7.12,<1
 docutils==0.15.2
 matplotlib>=3.1.0,<4
 networkx>=2.3,<3
-numpy>=1.19.4,<2
+numpy>=1.19.3,<2
 pandas>=1.0.5,<2
 pbr>=5.4.4,<6
 Pygments>=2.4.2,<3


### PR DESCRIPTION
# Thanks for contributing to GNPy

If it isn't much trouble, please send your contribution as patches to our Gerrit.
Here's [how to submit patches](https://review.gerrithub.io/Documentation/intro-gerrit-walkthrough-github.html), and here's a [list of stuff we are currently working on](https://review.gerrithub.io/p/Telecominfraproject/oopt-gnpy/+/dashboard/main:main).
Just sign in via your existing GitHub account.

However, if you feel more comfortable with filing GitHub PRs, we can work with that too.
