### PR TITLE
CI: do not "fail" branches upon coverage decrease

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,9 @@
 comment: off
+coverage:
+  status:
+    project:
+      default:
+        threshold: 5%
+    patch:
+      default:
+        only_pulls: true


### PR DESCRIPTION
Right now the project homepage on GitHub [shows an red failure](https://codecov.io/gh/Telecominfraproject/oopt-gnpy/commit/924c56850d77c53f8e5c46e21082e5510a8b00d5) due to [1]. While I agree that coverage reports are a useful metric, they are most relevant when considering patches (or changes) on their own. I do not think it makes any sense to show them on branches. When we merged that commit, the reviewer had the info about the coverage change, and we just do not have 100% coverage. Let's not pretend that that is a blocker.

Duplicate of https://review.gerrithub.io/c/Telecominfraproject/oopt-gnpy/+/516001 because I want to see this in the GitHub UI as well.