### PR TITLE
CI: always try to build a release wheel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: fedora-python/tox-github-action@v0.4
         with:
           tox_env: ${{ matrix.tox_env }}

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
 	pytest {env:CI_COVERAGE_OPTS:} -vv {posargs}
 	cover: coverage html -d cover
 	cover: coverage xml -o cover/coverage.xml
+	python setup.py bdist_wheel
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
This might be a wee bit controversial, I guess, because the Zuul jobs
look like there's a dedicated playbook for that
(playbooks/python/release.yaml). However, that would be one extra VM
launch, which feels wasteful. Let's waste the CPU cycles elsewhere --
during each "regular test build", produce a wheel as well.

It looks that these "wheels" are *the* format for distributing Python
packages now -- including the source code, of course. Since there's no
real support for tag review in Gerrit, I don't think I need Zuul for
release management, either, so I'll just rely on GitHub actions for
release upload, I guess. And for that, I need to "somehow" create a
wheel anyway, so let's just do this all the time to ensure that it
really works and never stops working.

Change-Id: Ib86852a386673cd4929a8059b19fa527cd4d5955