### PR TITLE
CI: docker: releases should update the `latest` tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,7 @@ jobs:
           push: true
           tags: |
             telecominfraproject/oopt-gnpy:${{ steps.extract_tag_name.outputs.GIT_DESC }}
+            telecominfraproject/oopt-gnpy:latest
 
   windows:
     name: Tests on Windows


### PR DESCRIPTION
We've been accidentally not updating the `latest` tag on Docker hub after switching from Travis CI to GitHub actions. Traditionally, we've assumed the `latest` points to the "latest release", so this patch makes it simple and will call any pushed "version tag" as the `latest`. This will become a problem if/when we start maintaining multiple releases, but I think it's a safe approach for now.

As before, there's also the `master` tag which always points to the, well, master branch of the repo.

The `.github/` prefix is special, which is why I'm pushing this as a PR instead of going through Gerrit -- that one would break replication.