### PR TITLE
Silence an irrelevant warning on LGTM.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,2 @@
+queries:
+- exclude: py/clear-text-logging-sensitive-data


### PR DESCRIPTION
*(Opening a PR so that hopefully LGTM will give me some early feedback before merging this.)*

By default, this service issues a warning for strings which format data like {uid}, flagging this pattern as related to antipatterns CWE-312, CWE-315 and CWE-359. This warning is not relevant for us because we never process sensitive information (if there are some NDA-covered data in the input, well, the user already has them, we're just using these).

Silence this warning (it's currently getting us an B rating, apparently).

See-also: https://lgtm.com/rules/1510014536001/
Change-Id: Id5cdd2c62e61a8329760d3fb79665737beb22378