### PR TITLE
tests: do not compare floating point numbers for equality

### DIFF
--- a/tests/test_equalization.py
+++ b/tests/test_equalization.py
@@ -221,10 +221,10 @@ def test_low_input_power(target_out, delta_pdb_per_channel, correction):
     }
     roadm = Roadm(**roadm_config)
     si = roadm(si, 'toto')
-    assert (watt2dbm(si.signal) == target - correction).all()
+    assert_allclose(watt2dbm(si.signal), target - correction, rtol=1e-5)
     # in other words check that if target is below input power, target is applied else power is unchanged
-    assert (((watt2dbm(signal) >= target) * target + (watt2dbm(signal) < target) * watt2dbm(signal))
-            == watt2dbm(si.signal)).all()
+    assert_allclose((watt2dbm(signal) >= target) * target + (watt2dbm(signal) < target) * watt2dbm(signal),
+                    watt2dbm(si.signal), rtol=1e-5)
 
 
 @pytest.mark.parametrize('target_out, delta_pdb_per_channel, correction',
@@ -273,7 +273,7 @@ def test_2low_input_power(target_out, delta_pdb_per_channel, correction):
     }
     roadm = Roadm(**roadm_config)
     si = roadm(si, 'toto')
-    assert (watt2dbm(si.signal) == target - correction).all()
+    assert_allclose(watt2dbm(si.signal), target - correction, rtol=1e-5)
 
 
 def net_setup(equipment):


### PR DESCRIPTION
GitHub CI started failing with the following error:
```diff
assert (watt2dbm(si.signal) == target - correction).all()
assert False
 +  where False = <built-in method all of numpy.ndarray object at 0x7f01c0ca94d0>()
 +    where <built-in method all of numpy.ndarray object at 0x7f01c0ca94d0> = array([-25.5, -24.5, -22.5, -25. , -27.5]) == array([-25.5, -24.5, -22.5, -25. , -27.5])
+array([-25.5, -24.5, -22.5, -25. , -27.5])
-array([-25.5, -24.5, -22.5, -25. , -27.5])
```
This is with code which has passed in the Zuul/Vexxhost CI.

It looks very similar to a regression that hit numpy 1.24.0, but the GitHub action log shows that this happens with numpy 1.24.1. Weird, and I'm not getting these differences locally, and also not on an ARM64 cloud VM.

Anyway, comparing floating point numbers for strict equality is futile, so let's use this opportunity to use a proper check for these.