### PR TITLE
docs: fix graphs on RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+  apt_packages:
+    - graphviz
 
 python:
   install:


### PR DESCRIPTION
At OFC I was talking with the OpenROADM people, and it turned out that our docs stopped rendering properly at RTD. It turned out that the build started skipping the bindep.txt file at some (unknown) point in time.

Reported-by: Aparaajitha G L <aparaajitha.gomathinayakamlatha@utdallas.edu>