### PR TITLE
Add total_loss parameter for fiber attenuation (OTDR measurement support)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ To learn how to contribute, please see CONTRIBUTING.md
 - Gabriele Galimberti (Cisco) <ggalimbe@cisco.com>
 - Gert Grammel (Juniper Networks) <ggrammel@juniper.net>
 - Giacomo Borraccini (NEC Laboratories America) <gborraccini@nec-labs.com>
+- Linqi Xiao (University of Texas at Dallas) <linqi.xiao@utdallas.edu>, <linqixiao2021@gmail.com>, <linqi.xiao@ieee.org>
 - Gilad Goldfarb (Facebook) <giladg@fb.com>
 - James Powell (Telecom Infra Project) <james.powell@telecominfraproject.com>
 - Jan Kundrát (Telecom Infra Project) <jkt@jankundrat.com>

--- a/gnpy/core/elements.py
+++ b/gnpy/core/elements.py
@@ -903,7 +903,14 @@ class Fiber(_Node):
             'con_in': self.params.con_in,
             'con_out': self.params.con_out
         }
-        if isinstance(self.params.loss_coef, ndarray):
+        if self.params.total_loss is not None:
+            if self.params.total_loss.size > 1:
+                params["total_loss_per_frequency"] = [
+                    {"frequency": frequency, "total_loss_value": round(float(tl), 6)}
+                    for frequency, tl in zip(self.params.f_loss_ref, self.params.total_loss)]
+            else:
+                params["total_loss"] = round(float(self.params.total_loss), 6)
+        elif isinstance(self.params.loss_coef, ndarray):
             params["loss_coef_per_frequency"] = [
                 {"frequency": frequency, "loss_coef_value": round(loss * 1e3, 6)}
                 for frequency, loss in zip(self.params.f_loss_ref, self.params.loss_coef)]

--- a/gnpy/tools/convert_legacy_yang.py
+++ b/gnpy/tools/convert_legacy_yang.py
@@ -25,6 +25,7 @@ from gnpy.tools.yang_convert_utils import convert_degree, convert_back_degree, \
     convert_design_band, convert_back_design_band, \
     convert_none_to_empty, convert_empty_to_none, \
     convert_loss_coeff_list, convert_back_loss_coeff_list, \
+    convert_total_loss_list, convert_back_total_loss_list, \
     ELEMENTS_KEY, PATH_REQUEST_KEY, RESPONSE_KEY, SPECTRUM_KEY, EQPT_TYPES, EDFA_CONFIG_KEYS, SIM_PARAMS_KEYS, \
     TOPO_NMSP, SERV_NMSP, EQPT_NMSP, SPECTRUM_NMSP, SIM_PARAMS_NMSP, EDFA_CONFIG_NMSP, RESP_NMSP, \
     dump_data, add_missing_default_type_variety, \
@@ -56,6 +57,7 @@ def legacy_to_yang(json_data: Dict) -> Dict:
         json_data = convert_degree(json_data)
         json_data = convert_design_band(json_data)
         json_data = convert_loss_coeff_list(json_data)
+        json_data = convert_total_loss_list(json_data)
         json_data = convert_raman_coef(json_data)
         json_data = {TOPO_NMSP: json_data}
     elif TOPO_NMSP in json_data:
@@ -63,6 +65,7 @@ def legacy_to_yang(json_data: Dict) -> Dict:
         json_data[TOPO_NMSP] = convert_degree(json_data[TOPO_NMSP])
         json_data[TOPO_NMSP] = convert_design_band(json_data[TOPO_NMSP])
         json_data[TOPO_NMSP] = convert_loss_coeff_list(json_data[TOPO_NMSP])
+        json_data[TOPO_NMSP] = convert_total_loss_list(json_data[TOPO_NMSP])
         json_data[TOPO_NMSP] = remove_null_region_city(json_data[TOPO_NMSP])
 
     # case of equipment json
@@ -149,11 +152,13 @@ def yang_to_legacy(json_data: Dict) -> Dict:
         json_data = convert_back_degree(json_data)
         json_data = convert_back_design_band(json_data)
         json_data = convert_back_loss_coeff_list(json_data)
+        json_data = convert_back_total_loss_list(json_data)
         json_data = convert_back_raman_coef(json_data)
     elif TOPO_NMSP in json_data:
         json_data = convert_back_degree(json_data[TOPO_NMSP])
         json_data = convert_back_design_band(json_data)
         json_data = convert_back_loss_coeff_list(json_data)
+        json_data = convert_back_total_loss_list(json_data)
         json_data = convert_back_raman_coef(json_data)
 
     # case of equipment json

--- a/gnpy/tools/yang_convert_utils.py
+++ b/gnpy/tools/yang_convert_utils.py
@@ -34,6 +34,8 @@ RESPONSE_KEY = 'response'
 SPECTRUM_KEY = 'spectrum'
 LOSS_COEF_KEY = 'loss_coef'
 LOSS_COEF_KEY_PER_FREQ = 'loss_coef_per_frequency'
+TOTAL_LOSS_KEY = 'total_loss'
+TOTAL_LOSS_KEY_PER_FREQ = 'total_loss_per_frequency'
 RAMAN_COEF_KEY = 'raman_coefficient'
 RAMAN_EFFICIENCY_KEY = 'raman_efficiency'
 EQPT_TYPES = ['Edfa', 'Transceiver', 'Fiber', 'Roadm']
@@ -396,6 +398,46 @@ def convert_back_loss_coeff_list(json_data: Dict) -> Dict:
                     'frequency': [item['frequency'] for item in loss_coef_per_frequency],
                     'value': [item['loss_coef_value'] for item in loss_coef_per_frequency]}
                 elem[PARAMS_KEY]['loss_coef'] = new_loss_coef_per_frequency
+    return json_data
+
+
+def convert_total_loss_list(json_data: Dict) -> Dict:
+    """Convert total_loss per-frequency dict format to YANG list format.
+
+    :param json_data: The input JSON topology data to convert.
+    :type json_data: Dict
+    :return: the converted JSON data
+    :rtype: Dict
+    """
+    for elem in json_data[ELEMENTS_KEY]:
+        if PARAMS_KEY in elem and TOTAL_LOSS_KEY in elem[PARAMS_KEY] \
+                and isinstance(elem[PARAMS_KEY][TOTAL_LOSS_KEY], dict):
+            total_loss_per_frequency = elem[PARAMS_KEY].pop(TOTAL_LOSS_KEY)
+            total_loss_list = total_loss_per_frequency.pop('value', None)
+            frequency_list = total_loss_per_frequency.pop('frequency', None)
+            if total_loss_list:
+                new_total_loss_per_frequency = [{'frequency': f, 'total_loss_value': v}
+                                                for f, v in zip(frequency_list, total_loss_list)]
+                elem[PARAMS_KEY][TOTAL_LOSS_KEY_PER_FREQ] = new_total_loss_per_frequency
+    return json_data
+
+
+def convert_back_total_loss_list(json_data: Dict) -> Dict:
+    """Convert YANG total_loss list format back to dict format.
+
+    :param json_data: The input JSON topology data to convert back
+    :type json_data: Dict
+    :return: the converted JSON data
+    :rtype: Dict
+    """
+    for elem in json_data[ELEMENTS_KEY]:
+        if PARAMS_KEY in elem and TOTAL_LOSS_KEY_PER_FREQ in elem[PARAMS_KEY]:
+            total_loss_per_frequency = elem[PARAMS_KEY].pop(TOTAL_LOSS_KEY_PER_FREQ)
+            if total_loss_per_frequency:
+                new_total_loss_per_frequency = {
+                    'frequency': [item['frequency'] for item in total_loss_per_frequency],
+                    'value': [item['total_loss_value'] for item in total_loss_per_frequency]}
+                elem[PARAMS_KEY][TOTAL_LOSS_KEY] = new_total_loss_per_frequency
     return json_data
 
 


### PR DESCRIPTION
## Summary

This PR adds support for specifying fiber attenuation as **total loss (dB)** instead of only via `loss_coef` (dB/km). This addresses the use case where users have OTDR measurements that report total span loss directly.

Resolves #441

## Changes

### `gnpy/core/parameters.py` (FiberParams)
- Accept `total_loss` as an alternative to `loss_coef`
- When `total_loss` is provided, derive `loss_coef = total_loss / length`
- Support both scalar and frequency-dependent `total_loss` (dict with `value` and `frequency` keys)
- Fully backward compatible: `loss_coef` continues to work unchanged
- `asdict()` preserves the original parameter (`total_loss` or `loss_coef`)

### `gnpy/core/elements.py` (Fiber)
- `to_json` exports `total_loss` / `total_loss_per_frequency` when total_loss was the input

### `gnpy/tools/yang_convert_utils.py` & `convert_legacy_yang.py`
- YANG format conversion support for `total_loss` / `total_loss_per_frequency`

### Tests
- Scalar total_loss → correct loss_coef derivation
- Frequency-dependent total_loss → correct per-frequency loss_coef
- Backward compatibility (loss_coef still works)
- Round-trip serialization via `asdict()`

## Usage Example

```json
{
  "uid": "fiber-span-1",
  "type": "Fiber",
  "params": {
    "length": 80,
    "length_units": "km",
    "total_loss": 16.0,
    "con_in": 0.5,
    "con_out": 0.5,
    "pmd_coef": 1.265e-15
  }
}
```

cc @jktjkt